### PR TITLE
Add application section to release configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,6 +6,9 @@ changelog:
     - title: "🐛 Bug Fixes"
       labels:
         - "bug"
+    - title: "🚀 New Application"
+      labels:
+        - "deployment"
     - title: "✨ New Features"
       labels:
         - "feature"


### PR DESCRIPTION
This pull request updates the release workflow configuration by adding a new section to categorize deployment-related changes in the changelog.

Changelog improvements:

* [`.github/release.yml`](diffhunk://#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213R9-R11): Added a "🚀 New Application" section with the "deployment" label to the changelog configuration, allowing deployment changes to be tracked separately in release notes.