### PR TITLE
Correct deployment label description formatting

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -28,4 +28,4 @@
 
 - name: "deployment"
   color: "52a9e9"
-  description: "New Application Deployed
+  description: "New Application Deployed"


### PR DESCRIPTION
This pull request makes a minor correction to the `deployment` label in the `.github/labels.yml` file by fixing a formatting issue in the label's description.