### PR TITLE
Add Omni Tools deployment configuration and documentation

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -75,6 +75,11 @@ This directory includes deployments for a variety of services, ranging from pers
   - **immich-machine-learning**: AI processing for smart features
 - **Use Case**: Ideal for users looking to manage and organize their photo and video collections with advanced AI capabilities.
 
+### 11. [Omni Tools](omni/README.md)
+- **Description**: Deploys Omni Tools, a self-hosted browser-based collection of everyday utility tools. It provides a lightweight, privacy-friendly alternative to scattered online services.
+- **Use Case**: Ideal for users who want a single, self-hosted destination for common utility tasks without relying on third-party websites.
+- **Dependencies**: Requires Traefik for proxying and certificate management.
+
 ## Service Versions
 
 | Service | Component | Version |
@@ -95,6 +100,7 @@ This directory includes deployments for a variety of services, ranging from pers
 | [Paperless](paperless/README.md) | tika | `3.2.3.0` |
 | [Portainer](portainer/README.md) | portainer-ce | `2.39.1` |
 | [Portainer](portainer/README.md) | portainer-agent | `2.39.1` |
+| [Omni Tools](omni/README.md) | omni-tools | `latest` |
 | [Traefik](traefik/README.md) | traefik | `3.6.11` |
 
 ## Prerequisites

--- a/deployments/omni/README.md
+++ b/deployments/omni/README.md
@@ -1,0 +1,64 @@
+# Omni Tools Deployment
+
+[![Ansible](https://img.shields.io/badge/Ansible-Automation-EE0000?logo=ansible&logoColor=white&style=flat-square)](https://docs.ansible.com/) [![Docker Swarm](https://img.shields.io/badge/Docker%20Swarm-Orchestration-2496ED?logo=docker&logoColor=white&style=flat-square)](https://docs.docker.com/engine/swarm/) [![Traefik](https://img.shields.io/badge/Traefik-HTTPS%20Access-24A1C1?logo=traefikproxy&logoColor=white&style=flat-square)](https://doc.traefik.io/traefik/) ![Omni Tools](https://img.shields.io/badge/Omni%20Tools-latest-5C5C5C?style=flat-square)
+
+This directory contains an Ansible-based deployment for **Omni Tools** using Docker Swarm and Traefik for HTTPS ingress. Omni Tools is a self-hosted, browser-based collection of everyday utility tools — a lightweight, privacy-friendly alternative to scattered online services.
+
+## What this deployment does
+
+- Stops any running `omni_omni` service before redeployment.
+- Renders a Docker Compose stack definition from a Jinja2 template.
+- Deploys the stack to Docker Swarm using `docker stack deploy`.
+- Uses Traefik labels to expose the Omni Tools UI over HTTPS using Let's Encrypt.
+- Cleans up temporary compose files after deployment.
+
+## Architecture overview
+
+The deployment is a single stateless service with no persistent storage requirements.
+
+- **Docker Swarm stack**: managed as a Swarm stack (`docker stack deploy`).
+- **Traefik**: handles ingress on the `proxy` overlay network, enforcing HTTPS and issuing Let's Encrypt certificates.
+- **Services**:
+  - `omni` – the Omni Tools web application, served on port 80 internally.
+
+## Prerequisites
+
+1. **Docker Swarm cluster already initialized** (at least one manager and one worker node).
+2. **Traefik stack deployed**, providing an external overlay network named `proxy`.
+3. **Ansible control node** with access to `inventory.yml` (see [`inventory.example.yml`](../../inventory.example.yml)) and Vault secrets (see [`vault.template.yml`](../../vault.template.yml)).
+
+## Deployment
+
+```bash
+ansible-playbook -i ../../inventory.yml deployments/omni/deploy.yml
+```
+
+## Configuration
+
+### Key variables
+
+- `vault.shared.general.domain` – the base domain used to construct the service URL (`omni.<domain>`).
+
+This value is sourced from Ansible Vault. See [`vault.template.yml`](../../vault.template.yml) at the repo root for the full variable reference.
+
+## Important paths
+
+- `deployments/omni/deploy.yml` – main playbook
+- `deployments/omni/roles/deploy/tasks/main.yml` – stops existing service, deploys stack, and cleans up
+- `deployments/omni/templates/docker-compose.yaml` – the Docker stack template
+
+## Security considerations
+
+- All traffic is redirected from HTTP to HTTPS via a Traefik middleware rule.
+- TLS certificates are managed automatically by Traefik using the Let's Encrypt `letsencrypt` resolver.
+- The container is deployed on worker nodes only and runs as a single replica.
+- The `ai.ix.auto-update=true` label enables automatic image updates via the [Cioban](../cioban/README.md) service.
+
+## Troubleshooting
+
+Common issues and their resolutions:
+
+- **Service not accessible**: confirm the `proxy` overlay network exists and Traefik is running.
+- **Certificate not issued**: verify DNS resolves `omni.<domain>` to the cluster's public IP.
+- **Deployment fails**: check that Docker Swarm is initialized and the target worker nodes are healthy.
+- **Stale service**: the playbook stops `omni_omni` before redeployment; if the stop step fails, manually remove the service with `docker service rm omni_omni`.

--- a/deployments/omni/deploy.yml
+++ b/deployments/omni/deploy.yml
@@ -1,0 +1,13 @@
+
+- name: Deploy Omni  
+  hosts: manager  
+  order: shuffle  
+  become: true      
+  vars:
+    omni_deploy_host: "{{ ansible_play_hosts_all | first }}"
+
+  tasks:
+    - name: Deploy Omni stack
+      ansible.builtin.include_role:
+        name: deploy
+      when: inventory_hostname == omni_deploy_host

--- a/deployments/omni/deploy.yml
+++ b/deployments/omni/deploy.yml
@@ -1,12 +1,15 @@
-
-- name: Deploy Omni  
-  hosts: manager  
-  order: shuffle  
-  become: true      
+# Deploy the Omni stack once from a single manager node.
+- name: Deploy Omni
+  # Target manager nodes because stack deployment is a manager-only operation.
+  hosts: manager
+  order: shuffle
+  become: true
   vars:
+    # Select one host from the play host list to avoid duplicate stack deploys.
     omni_deploy_host: "{{ ansible_play_hosts_all | first }}"
 
   tasks:
+    # Delegate stack deployment logic to the role, but execute it on one host only.
     - name: Deploy Omni stack
       ansible.builtin.include_role:
         name: deploy

--- a/deployments/omni/roles/deploy/tasks/main.yml
+++ b/deployments/omni/roles/deploy/tasks/main.yml
@@ -1,19 +1,23 @@
 ---
-
+# Reuse shared pre-deploy logic to stop any existing Omni service
+# before rendering and redeploying the stack.
 - name: Run shared Docker prerequisites and cleanup
   ansible.builtin.include_role:
     name: docker_prereqs_and_stop
   vars:
+    # Swarm service name generated from stack + service: omni_omni.
     docker_prereqs_and_stop_services_to_stop:
       - omni_omni
 
+# Render compose template and deploy/update the Omni stack.
 - name: Deploy Services
   ansible.builtin.include_role:
     name: copy_and_deploy
   vars:
+    # Must match the target stack name in Docker Swarm.
     copy_and_deploy_stack_name: omni
 
-
+# Remove temporary compose artifacts created during deployment.
 - name: Clean up compose directory
   ansible.builtin.include_role:
     name: cleanup

--- a/deployments/omni/roles/deploy/tasks/main.yml
+++ b/deployments/omni/roles/deploy/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Run shared Docker prerequisites and cleanup
+  ansible.builtin.include_role:
+    name: docker_prereqs_and_stop
+  vars:
+    docker_prereqs_and_stop_services_to_stop:
+      - omni_omni
+
+- name: Deploy Services
+  ansible.builtin.include_role:
+    name: copy_and_deploy
+  vars:
+    copy_and_deploy_stack_name: omni
+
+
+- name: Clean up compose directory
+  ansible.builtin.include_role:
+    name: cleanup

--- a/deployments/omni/templates/docker-compose.yaml
+++ b/deployments/omni/templates/docker-compose.yaml
@@ -1,37 +1,46 @@
 version: '3.8'
 
 services:
+  # Omni Tools web application exposed through Traefik.
   omni:
     image: iib0011/omni-tools:latest
     container_name: omni-tools
     restart: unless-stopped
     networks:
-      proxy: 
+      # Attach to the shared Traefik ingress network.
+      proxy:
         aliases:
-          - omni.{{ vault.shared.general.domain }} 
-    deploy: 
+          - omni.{{ vault.shared.general.domain }}
+    deploy:
+      # Reduce downtime during image updates.
       update_config:
-        order: start-first 
+        order: start-first
+      # Keep app workloads on workers; managers handle control-plane duties.
       placement:
         constraints: [node.role == worker]
-      mode: replicated 
+      mode: replicated
       replicas: 1
-      labels: 
-        - "traefik.enable=true" 
-        - "traefik.http.routers.omni.entrypoints=web" 
-        - "traefik.http.routers.omni.rule=Host(`omni.{{ vault.shared.general.domain }}`)" 
-        - "traefik.http.middlewares.omni-https-redirect.redirectscheme.scheme=https" 
-        - "traefik.http.routers.omni.middlewares=omni-https-redirect" 
-        - "traefik.http.routers.omni-secure.entrypoints=websecure" 
-        - "traefik.http.routers.omni-secure.rule=Host(`omni.{{ vault.shared.general.domain }}`)" 
-        - "traefik.http.routers.omni-secure.tls=true" 
-        - "traefik.http.routers.omni-secure.service=omni" 
-        - "traefik.http.routers.omni-secure.tls.certresolver=letsencrypt" 
-        - "traefik.http.services.omni.loadbalancer.server.port=80" 
-        - "traefik.http.services.omni.loadbalancer.passhostheader=true" 
-        - "traefik.docker.network=proxy" 
-        - "ai.ix.auto-update=true" 
+      labels:
+        # Enable Traefik and expose HTTP for redirect middleware only.
+        - "traefik.enable=true"
+        - "traefik.http.routers.omni.entrypoints=web"
+        - "traefik.http.routers.omni.rule=Host(`omni.{{ vault.shared.general.domain }}`)"
+        - "traefik.http.middlewares.omni-https-redirect.redirectscheme.scheme=https"
+        - "traefik.http.routers.omni.middlewares=omni-https-redirect"
+        # Secure router for real traffic over TLS.
+        - "traefik.http.routers.omni-secure.entrypoints=websecure"
+        - "traefik.http.routers.omni-secure.rule=Host(`omni.{{ vault.shared.general.domain }}`)"
+        - "traefik.http.routers.omni-secure.tls=true"
+        - "traefik.http.routers.omni-secure.service=omni"
+        - "traefik.http.routers.omni-secure.tls.certresolver=letsencrypt"
+        # Forward requests to Omni's internal HTTP listener.
+        - "traefik.http.services.omni.loadbalancer.server.port=80"
+        - "traefik.http.services.omni.loadbalancer.passhostheader=true"
+        - "traefik.docker.network=proxy"
+        # Enables Cioban-driven automated image updates.
+        - "ai.ix.auto-update=true"
 
 networks:
-  proxy: 
+  # External network created by Traefik deployment.
+  proxy:
     external: true

--- a/deployments/omni/templates/docker-compose.yaml
+++ b/deployments/omni/templates/docker-compose.yaml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  omni:
+    image: iib0011/omni-tools:latest
+    container_name: omni-tools
+    restart: unless-stopped
+    networks:
+      proxy: 
+        aliases:
+          - omni.{{ vault.shared.general.domain }} 
+    deploy: 
+      update_config:
+        order: start-first 
+      placement:
+        constraints: [node.role == worker]
+      mode: replicated 
+      replicas: 1
+      labels: 
+        - "traefik.enable=true" 
+        - "traefik.http.routers.omni.entrypoints=web" 
+        - "traefik.http.routers.omni.rule=Host(`omni.{{ vault.shared.general.domain }}`)" 
+        - "traefik.http.middlewares.omni-https-redirect.redirectscheme.scheme=https" 
+        - "traefik.http.routers.omni.middlewares=omni-https-redirect" 
+        - "traefik.http.routers.omni-secure.entrypoints=websecure" 
+        - "traefik.http.routers.omni-secure.rule=Host(`omni.{{ vault.shared.general.domain }}`)" 
+        - "traefik.http.routers.omni-secure.tls=true" 
+        - "traefik.http.routers.omni-secure.service=omni" 
+        - "traefik.http.routers.omni-secure.tls.certresolver=letsencrypt" 
+        - "traefik.http.services.omni.loadbalancer.server.port=80" 
+        - "traefik.http.services.omni.loadbalancer.passhostheader=true" 
+        - "traefik.docker.network=proxy" 
+        - "ai.ix.auto-update=true" 
+
+networks:
+  proxy: 
+    external: true


### PR DESCRIPTION
This pull request introduces a new deployment for Omni Tools, a self-hosted collection of browser-based utility tools, to the infrastructure. It adds documentation, deployment playbooks, and configuration templates to enable easy setup of Omni Tools using Ansible, Docker Swarm, and Traefik for secure HTTPS access. The deployment is designed to be stateless, easy to update, and integrates with existing infrastructure standards.

**Omni Tools Deployment Addition**

*Documentation & Service Listing*
- Added an entry for Omni Tools in the main `deployments/README.md`, including a description, use case, and dependency on Traefik. Also updated the service version table to include Omni Tools. [[1]](diffhunk://#diff-ebc8e31d192efecb241e3c5dba4116603b4e52ecd4b1630e86202d34ccd1a731R78-R82) [[2]](diffhunk://#diff-ebc8e31d192efecb241e3c5dba4116603b4e52ecd4b1630e86202d34ccd1a731R103)
- Added a comprehensive `deployments/omni/README.md` with instructions, architecture overview, prerequisites, and troubleshooting for deploying Omni Tools.

*Deployment Configuration & Automation*
- Introduced an Ansible playbook (`deployments/omni/deploy.yml`) to automate the deployment of the Omni Tools stack on Docker Swarm manager nodes.
- Added a role-based Ansible task set (`deployments/omni/roles/deploy/tasks/main.yml`) to handle Docker prerequisites, stack deployment, and cleanup.
- Provided a Docker Compose template (`deployments/omni/templates/docker-compose.yaml`) for the Omni Tools service, including Traefik labels for HTTPS ingress, auto-update labeling, and Swarm-specific configuration for secure and reliable deployment.