### PR TITLE
Add Dozzle deployment configuration and documentation

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -13,25 +13,25 @@ This directory includes deployments for a variety of services, ranging from pers
 
 ## Deployments
 
-### 1. [Personal Blog](blog/README.md)
-- **Description**: Deploys multiple instances of a private Docker image for a personal blog. This deployment demonstrates how to handle private registries and update services when new image versions become available.
-- **Use Case**: Ideal for hosting a personal website or blog with high availability.
-- **Dependencies**: Requires Traefik for proxying and certificate management.
-
-### 2. [Cioban](cioban/README.md)
+### 1. [Cioban](cioban/README.md)
 - **Description**: Automates the process of updating Docker services when new image versions are available. It monitors services with specific labels and updates them according to their deployment policies.
 - **Use Case**: Ensures services remain up-to-date with minimal manual intervention.
 - **Dependencies**: Requires access to the Docker socket and Traefik for proxying.
 
-### 3. [Core Deployments](core-deployments/README.md)
+### 2. [Core Deployments](core-deployments/README.md)
 - **Description**: A collection of essential services required for the rest of the deployments to function properly. This includes Traefik and Dynamic DNS.
 - **Use Case**: Deploy this playbook first to set up the foundational services for the cluster.
 - **Dependencies**: None, but it is recommended to run this playbook before deploying other services.
 
-### 4. [DDNS](ddns/README.md)
+### 3. [DDNS](ddns/README.md)
 - **Description**: Dynamically updates DNS records to reflect the public IP address of the home lab's internet gateway. This ensures services are accessible via domain names.
 - **Use Case**: Useful for home labs with dynamic IP addresses.
 - **Dependencies**: Requires a DNS provider that supports API-based updates (e.g., Cloudflare).
+
+### 4. [Dozzle](dozzle/README.md)
+- **Description**: Deploys Dozzle, a lightweight real-time web UI for viewing Docker container logs across the swarm.
+- **Use Case**: Ideal for quickly troubleshooting services and inspecting logs from a browser without SSHing into nodes.
+- **Dependencies**: Requires Traefik for proxying and certificate management, and Docker socket access on target nodes.
 
 ### 5. [Gitea](gitea/README.md)
 - **Description**: Deploys a self-hosted Git service for managing repositories, similar to GitHub or GitLab.
@@ -43,26 +43,7 @@ This directory includes deployments for a variety of services, ranging from pers
 - **Use Case**: Perfect for managing and automating smart home devices.
 - **Dependencies**: Requires Traefik for proxying and certificate management.
 
-### 7. [NFS Backup](nfs-backup/README.md)
-- **Description**: Provides enterprise-grade automated backups for Docker Swarm NFS shared volumes using Restic with S3 storage backend. Implements a comprehensive backup strategy with three coordinated services:
-  - **backup**: Creates hourly encrypted incremental backups
-  - **prune**: Manages retention policies (keeping 24 latest, 7 daily, 4 weekly, and 4 monthly backups)
-  - **check**: Performs regular integrity verification of the backup repository
-- **Use Case**: Critical data protection for containerized applications with secure off-site storage
-- **Security**: All backups are strongly encrypted and services operate with least-privilege principles
-- **Dependencies**: Requires NFS volumes mounted at `/exports/docker` and S3-compatible storage credentials
-
-### 8. [Portainer](portainer/README.md)
-- **Description**: Provides a web-based interface for managing Docker and Docker Swarm. While deployments are managed by Ansible, Portainer offers a convenient UI for monitoring and manual management.
-- **Use Case**: Useful for visualizing and managing the cluster's status and activity.
-- **Dependencies**: Requires Traefik for proxying and certificate management.
-
-### 9. [Traefik](traefik/README.md)
-- **Description**: Acts as a reverse proxy for other services, enabling name resolution instead of relying on IP addresses and ports. It also integrates with DNS providers to issue valid HTTPS certificates.
-- **Use Case**: A critical component for managing traffic and securing connections in the cluster.
-- **Dependencies**: None, but it is recommended to deploy Traefik first.
-
-### 10. [Immich](immich/README.md)
+### 7. [Immich](immich/README.md)
 - **Description**: Immich is a high-performance self-hosted photo and video management solution that serves as a complete alternative to Google Photos. Features include:
   - Web interface and mobile apps for photo browsing and automatic backup
   - AI-powered features including face recognition and object detection
@@ -75,10 +56,34 @@ This directory includes deployments for a variety of services, ranging from pers
   - **immich-machine-learning**: AI processing for smart features
 - **Use Case**: Ideal for users looking to manage and organize their photo and video collections with advanced AI capabilities.
 
-### 11. [Omni Tools](omni/README.md)
+### 8. [NFS Backup](nfs-backup/README.md)
+- **Description**: Provides enterprise-grade automated backups for Docker Swarm NFS shared volumes using Restic with S3 storage backend. Implements a comprehensive backup strategy with three coordinated services:
+  - **backup**: Creates hourly encrypted incremental backups
+  - **prune**: Manages retention policies (keeping 24 latest, 7 daily, 4 weekly, and 4 monthly backups)
+  - **check**: Performs regular integrity verification of the backup repository
+- **Use Case**: Critical data protection for containerized applications with secure off-site storage
+- **Security**: All backups are strongly encrypted and services operate with least-privilege principles
+- **Dependencies**: Requires NFS volumes mounted at `/exports/docker` and S3-compatible storage credentials
+
+### 9. [Omni Tools](omni/README.md)
 - **Description**: Deploys Omni Tools, a self-hosted browser-based collection of everyday utility tools. It provides a lightweight, privacy-friendly alternative to scattered online services.
 - **Use Case**: Ideal for users who want a single, self-hosted destination for common utility tasks without relying on third-party websites.
 - **Dependencies**: Requires Traefik for proxying and certificate management.
+
+### 10. [Personal Blog](blog/README.md)
+- **Description**: Deploys multiple instances of a private Docker image for a personal blog. This deployment demonstrates how to handle private registries and update services when new image versions become available.
+- **Use Case**: Ideal for hosting a personal website or blog with high availability.
+- **Dependencies**: Requires Traefik for proxying and certificate management.
+
+### 11. [Portainer](portainer/README.md)
+- **Description**: Provides a web-based interface for managing Docker and Docker Swarm. While deployments are managed by Ansible, Portainer offers a convenient UI for monitoring and manual management.
+- **Use Case**: Useful for visualizing and managing the cluster's status and activity.
+- **Dependencies**: Requires Traefik for proxying and certificate management.
+
+### 12. [Traefik](traefik/README.md)
+- **Description**: Acts as a reverse proxy for other services, enabling name resolution instead of relying on IP addresses and ports. It also integrates with DNS providers to issue valid HTTPS certificates.
+- **Use Case**: A critical component for managing traffic and securing connections in the cluster.
+- **Dependencies**: None, but it is recommended to deploy Traefik first.
 
 ## Service Versions
 
@@ -86,6 +91,7 @@ This directory includes deployments for a variety of services, ranging from pers
 |---------|-----------|:-------:|
 | [Cioban](cioban/README.md) | cioban | `0.17.14` |
 | [DDNS](ddns/README.md) | cloudflare-ddns | `1.15.1` |
+| [Dozzle](dozzle/README.md) | dozzle | `latest` |
 | [Gitea](gitea/README.md) | server | `1.25.5` |
 | [Gitea](gitea/README.md) | act_runner | `0.2.12` |
 | [Home Assistant](home-assistant/README.md) | home-assistant | `2026.3.3` |

--- a/deployments/dozzle/README.md
+++ b/deployments/dozzle/README.md
@@ -1,0 +1,68 @@
+# Dozzle Deployment
+
+[![Ansible](https://img.shields.io/badge/Ansible-Automation-EE0000?logo=ansible&logoColor=white&style=flat-square)](https://docs.ansible.com/) [![Docker Swarm](https://img.shields.io/badge/Docker%20Swarm-Orchestration-2496ED?logo=docker&logoColor=white&style=flat-square)](https://docs.docker.com/engine/swarm/) [![Traefik](https://img.shields.io/badge/Traefik-HTTPS%20Access-24A1C1?logo=traefikproxy&logoColor=white&style=flat-square)](https://doc.traefik.io/traefik/) ![Dozzle](https://img.shields.io/badge/Dozzle-latest-5C5C5C?style=flat-square)
+
+This directory contains an Ansible-based deployment for **Dozzle** using Docker Swarm and Traefik for HTTPS ingress. Dozzle provides a lightweight real-time log viewer for Docker containers, making it easy to inspect service logs from a browser.
+
+## What this deployment does
+
+- Stops any running `dozzle_dozzel` service before redeployment.
+- Renders a Docker Compose stack definition from a Jinja2 template.
+- Deploys the stack to Docker Swarm using `docker stack deploy`.
+- Exposes Dozzle through Traefik with automatic HTTPS redirection and Let's Encrypt TLS certificates.
+- Cleans up temporary compose files after deployment.
+
+## Architecture overview
+
+The deployment runs a single Dozzle service in **global** mode so each swarm node can run an instance.
+
+- **Docker Swarm stack**: managed as a stack named `dozzle`.
+- **Traefik**: routes external traffic via the shared `proxy` overlay network.
+- **Services**:
+  - `dozzle` - Dozzle web UI on internal port `8080`, configured with `DOZZLE_MODE=swarm`.
+- **Networks**:
+  - `proxy` (external) - used by Traefik for ingress.
+  - `dozzle` (overlay) - service-local swarm network.
+
+## Prerequisites
+
+1. **Docker Swarm cluster already initialized** (at least one manager node).
+2. **Traefik stack deployed**, providing an external overlay network named `proxy`.
+3. **Ansible control node** with access to `inventory.yml` (see [`inventory.example.yml`](../../inventory.example.yml)) and Vault secrets (see [`vault.template.yml`](../../vault.template.yml)).
+4. **Docker socket access** on target nodes (`/var/run/docker.sock`), since Dozzle reads logs directly from the Docker API.
+
+## Deployment
+
+```bash
+ansible-playbook -i ../../inventory.yml deployments/dozzle/deploy.yml
+```
+
+## Configuration
+
+### Key variables
+
+- `vault.shared.general.domain` - the base domain used to construct the service URL (`dozzle.<domain>`).
+
+This value is sourced from Ansible Vault. See [`vault.template.yml`](../../vault.template.yml) at the repo root for the full variable reference.
+
+## Important paths
+
+- `deployments/dozzle/deploy.yml` - main playbook
+- `deployments/dozzle/roles/deploy/tasks/main.yml` - pre-cleanup, stack deployment, and cleanup steps
+- `deployments/dozzle/templates/docker-compose.yaml` - Docker stack template
+
+## Security considerations
+
+- All traffic is redirected from HTTP to HTTPS by Traefik middleware.
+- TLS certificates are issued automatically using the Let's Encrypt `letsencrypt` resolver.
+- The Dozzle container mounts `/var/run/docker.sock`, which grants broad visibility into container runtime metadata and logs. Restrict access to the Dozzle URL and trusted users.
+- The `ai.ix.auto-update=true` label enables automatic image updates via the [Cioban](../cioban/README.md) service.
+
+## Troubleshooting
+
+Common issues and their resolutions:
+
+- **Service not accessible**: confirm Traefik is running and DNS resolves `dozzle.<domain>` to your cluster ingress IP.
+- **TLS certificate issues**: verify Traefik ACME configuration and that `web`/`websecure` entrypoints are active.
+- **Missing logs**: ensure `/var/run/docker.sock` is mounted and readable by the Dozzle container.
+- **Deployment conflicts**: if an old service remains, manually remove it with `docker service rm dozzle_dozzel` and redeploy.

--- a/deployments/dozzle/deploy.yml
+++ b/deployments/dozzle/deploy.yml
@@ -1,0 +1,16 @@
+# Deploy the dozzle stack once from a single manager node.
+- name: Deploy dozzle
+  # Target manager nodes because stack deployment is a manager-only operation.
+  hosts: manager
+  order: shuffle
+  become: true
+  vars:
+    # Select one host from the play host list to avoid duplicate stack deploys.
+    dozzle_deploy_host: "{{ ansible_play_hosts_all | first }}"
+
+  tasks:
+    # Delegate stack deployment logic to the role, but execute it on one host only.
+    - name: Deploy dozzle stack
+      ansible.builtin.include_role:
+        name: deploy
+      when: inventory_hostname == dozzle_deploy_host

--- a/deployments/dozzle/roles/deploy/tasks/main.yml
+++ b/deployments/dozzle/roles/deploy/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+# Reuse shared pre-deploy logic to stop any existing dozzle service
+# before rendering and redeploying the stack.
+- name: Run shared Docker prerequisites and cleanup
+  ansible.builtin.include_role:
+    name: docker_prereqs_and_stop
+  vars:
+    # Swarm service name generated from stack + service: dozzle_dozzel.
+    docker_prereqs_and_stop_services_to_stop:
+      - dozzle_dozzel
+
+# Render compose template and deploy/update the dozzle stack.
+- name: Deploy Services
+  ansible.builtin.include_role:
+    name: copy_and_deploy
+  vars:
+    # Must match the target stack name in Docker Swarm.
+    copy_and_deploy_stack_name: dozzle
+
+# Remove temporary compose artifacts created during deployment.
+- name: Clean up compose directory
+  ansible.builtin.include_role:
+    name: cleanup

--- a/deployments/dozzle/templates/docker-compose.yaml
+++ b/deployments/dozzle/templates/docker-compose.yaml
@@ -1,0 +1,46 @@
+version: '3.8'
+
+services:
+  # dozzle web application exposed through Traefik.
+  dozzle:
+    image: amir20/dozzle:latest
+    container_name: dozzle
+    restart: unless-stopped
+    environment:
+      - DOZZLE_MODE=swarm
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - dozzle
+      - proxy
+    deploy:
+      # Reduce downtime during image updates.
+      update_config:
+        order: stop-first
+      mode: global
+      labels:
+        # Enable Traefik and expose HTTP for redirect middleware only.
+        - "traefik.enable=true"
+        - "traefik.http.routers.dozzle.entrypoints=web"
+        - "traefik.http.routers.dozzle.rule=Host(`dozzle.{{ vault.shared.general.domain }}`)"
+        - "traefik.http.middlewares.dozzle-https-redirect.redirectscheme.scheme=https"
+        - "traefik.http.routers.dozzle.middlewares=dozzle-https-redirect"
+        # Secure router for real traffic over TLS.
+        - "traefik.http.routers.dozzle-secure.entrypoints=websecure"
+        - "traefik.http.routers.dozzle-secure.rule=Host(`dozzle.{{ vault.shared.general.domain }}`)"
+        - "traefik.http.routers.dozzle-secure.tls=true"
+        - "traefik.http.routers.dozzle-secure.service=dozzle"
+        - "traefik.http.routers.dozzle-secure.tls.certresolver=letsencrypt"
+        # Forward requests to Dozzle's internal HTTP listener.
+        - "traefik.http.services.dozzle.loadbalancer.server.port=8080"
+        - "traefik.http.services.dozzle.loadbalancer.passhostheader=true"
+        - "traefik.docker.network=proxy"
+        # Enables Cioban-driven automated image updates.
+        - "ai.ix.auto-update=true"
+
+networks:
+  # External network created by Traefik deployment.
+  proxy:
+    external: true
+  dozzle:
+    driver: overlay


### PR DESCRIPTION
This pull request introduces a new deployment for Dozzle, a real-time Docker log viewer, into the Docker Swarm/Ansible deployment suite. It also reorganises the deployment documentation in `deployments/README.md` to accommodate the new service and improve clarity. The main changes are the addition of all necessary Ansible playbooks, roles, and templates for Dozzle, as well as updates to the service listing and order in the documentation.

**Additions and improvements related to Dozzle:**

* Added a new `dozzle` deployment directory, including a comprehensive `README.md` describing architecture, prerequisites, configuration, and security considerations.
* Implemented the Ansible playbook (`deploy.yml`) and supporting roles to automate Dozzle deployment as a Docker Swarm stack, ensuring only one manager node performs the deployment. [[1]](diffhunk://#diff-83818c36ff1e771bf52253d8d238dabe6976327a81013a61ecaf4a59905b0162R1-R16) [[2]](diffhunk://#diff-8604faa05010b360008d574b2c7df31c38e0ef8caf88f2f9987273a608fff5bfR1-R23)
* Created a Docker Compose template with Traefik integration, global service mode, and labels for HTTPS, automatic updates, and log access.

**Documentation and service listing updates:**

* Updated `deployments/README.md` to:
  - Insert Dozzle as a documented deployment, including its description, use case, and dependencies.
  - Reorder and clarify the numbering and grouping of all deployments for consistency and improved readability. [[1]](diffhunk://#diff-ebc8e31d192efecb241e3c5dba4116603b4e52ecd4b1630e86202d34ccd1a731L46-R46) [[2]](diffhunk://#diff-ebc8e31d192efecb241e3c5dba4116603b4e52ecd4b1630e86202d34ccd1a731L78-R94)
  - Add Dozzle to the service version table.

These changes collectively make it easier to deploy and manage Dozzle alongside other services in the stack, while keeping the documentation accurate and up-to-date.