### PR TITLE
Bump Home Assistant versions and update Docker login tasks

### DIFF
--- a/deployments/home-assistant/group_vars/all.yml
+++ b/deployments/home-assistant/group_vars/all.yml
@@ -7,9 +7,9 @@ home_assistant:
 
   # Pinned image tags for reproducible deployments
   versions:
-    homeassistant: "2026.3.3"
-    zigbee2mqtt: "2.9.1"
-    mqtt: "2.1-alpine"
+    homeassistant: "2026.4.1"
+    zigbee2mqtt: "2.9.2"
+    mqtt: "2.1.2-alpine"
 
 # Notes:
 # - All vault.services.home_assistant.* variables must be defined and encrypted in Ansible Vault.

--- a/deployments/home-assistant/templates/docker-compose.yaml
+++ b/deployments/home-assistant/templates/docker-compose.yaml
@@ -11,7 +11,6 @@
 # - Zigbee2MQTT: Bridge between Zigbee devices and MQTT protocol
 # - Mosquitto MQTT: Message broker for device-to-service communication
 # - Traefik Integration: Reverse proxy with automatic SSL certificates
-# - NFS Storage: Persistent storage for configurations and data
 #
 # Network Design:
 # - proxy: External network for Traefik reverse proxy communication
@@ -20,7 +19,6 @@
 # Security Features:
 # - Automatic HTTPS redirection and SSL certificate management
 # - Isolated network segments for external and internal traffic
-# - Persistent storage on NFS for data protection
 # ============================================================================
 
 version: '3.8'
@@ -74,9 +72,8 @@ services:
         # Zigbee2MQTT services within the stack.
 
     volumes:
-      - /mnt/nfs/docker/home_assistant:/config
-      # Primary configuration and data storage on NFS.
-      #
+      - /exports/docker/home_assistant:/config
+      # Persistent storage for Home Assistant configuration and state data.
       # Contains:
       # - configuration.yaml: Main Home Assistant configuration
       # - automations.yaml: Automation definitions
@@ -123,6 +120,9 @@ services:
       # Single instance deployment for Home Assistant.
       # Home Assistant doesn't support clustering, so only one instance
       # should run to prevent database conflicts and state inconsistencies.
+      placement:
+        constraints:
+          - node.labels.storage == true             # Target nodes with storage capabilities
 
       labels:
         # Traefik configuration labels for reverse proxy integration
@@ -169,7 +169,7 @@ services:
     container_name: zigbee2mqtt
     # Container identifier for service management and logging.
 
-    image: "koenkk/zigbee2mqtt:{{ home_assistant.versions.zigbee2mqtt }}"
+    image: "ghcr.io/koenkk/zigbee2mqtt:{{ home_assistant.versions.zigbee2mqtt }}"
     # Official Zigbee2MQTT container image.
     #
     # Version Considerations:
@@ -182,7 +182,7 @@ services:
     # Critical for maintaining Zigbee network coordinator connection.
 
     volumes:
-      - /mnt/nfs/docker/home_assistant/zigbee2mqtt/data:/app/data
+      - /exports/docker/home_assistant/zigbee2mqtt/data:/app/data
       # Persistent storage for Zigbee2MQTT configuration and device database.
       #
       # Critical Data:
@@ -216,6 +216,9 @@ services:
       replicas: 1
       # Single instance deployment required for Zigbee coordinator management.
       # Multiple instances would conflict for USB coordinator access.
+      placement:
+        constraints:
+          - node.labels.storage == true             # Target nodes with storage capabilities
 
       labels:
         # Traefik reverse proxy configuration for web interface
@@ -257,7 +260,7 @@ services:
     # Critical service as it's the communication backbone for IoT devices.
 
     volumes:
-      - "/mnt/nfs/docker/home_assistant/mosquitto:/mosquitto"
+      - "/exports/docker/home_assistant/mosquitto:/mosquitto"
       # Persistent storage for MQTT broker configuration and data.
       #
       # Directory Structure:
@@ -293,6 +296,9 @@ services:
       # Single broker instance for message consistency.
       # MQTT clustering requires additional configuration and is typically
       # not needed for home automation scenarios.
+      placement:
+        constraints:
+          - node.labels.storage == true             # Target nodes with storage capabilities
 
       labels:
         - "traefik.enable=false"
@@ -327,14 +333,11 @@ networks:
 # 1. Hardware Requirements:
 #    - Zigbee USB coordinator (e.g., CC2531, ConBee II, Sonoff Zigbee 3.0)
 #    - Sufficient RAM for Home Assistant database growth
-#    - Reliable network connectivity for NFS storage
-#    - UPS or reliable power for coordinator and NFS storage
 #
 # 2. Network Configuration:
 #    - Ensure proxy network exists before deployment
 #    - Configure DNS records for subdomains
 #    - Verify firewall rules allow necessary ports
-#    - Test NFS connectivity from all Swarm nodes
 #
 # 3. Security Considerations:
 #    - Enable MQTT authentication in production
@@ -344,7 +347,6 @@ networks:
 #    - Backup encryption for sensitive automation data
 #
 # 4. Backup Strategy:
-#    - Regular NFS storage backups including all service data
 #    - Zigbee coordinator backup before major changes
 #    - Configuration version control for disaster recovery
 #    - Test restore procedures in non-production environment
@@ -360,7 +362,6 @@ networks:
 #    - Home Assistant doesn't support horizontal scaling
 #    - MQTT broker can be clustered if needed
 #    - Consider load balancing for high-traffic scenarios
-#    - Monitor NFS performance under load
 #
 # 7. Troubleshooting:
 #    - Check service logs: docker service logs [service_name]

--- a/deployments/home-assistant/templates/zigbee/configuration.yaml
+++ b/deployments/home-assistant/templates/zigbee/configuration.yaml
@@ -82,6 +82,24 @@ serial:
         # Note: Actual maximum depends on coordinator hardware and regulations.
 
 # ============================================================================
+# Global Advanced Settings
+# ============================================================================
+advanced:
+    last_seen: ISO_8601_local
+    # Adds a last_seen timestamp to device payloads.
+    # ISO_8601_local is usually the nicest option for Home Assistant.
+
+# ============================================================================
+# Device Availability Monitoring
+# ============================================================================
+availability:
+    enabled: true
+    active:
+        timeout: 10
+    passive:
+        timeout: 1500
+
+# ============================================================================
 # Web Interface Configuration
 # ============================================================================
 frontend:

--- a/docker-swarm/roles/docker_install/tasks/main.yml
+++ b/docker-swarm/roles/docker_install/tasks/main.yml
@@ -66,11 +66,16 @@
     append: true  # Add to the docker group without removing existing groups.
   # This step allows the current user to run Docker commands without using `sudo`.
 
-- name: Docker login to registry
+- name: Docker login to private registries
   community.docker.docker_login:
-    username: "{{ registry_user }}"
-    password: "{{ registry_password }}"
-    registry_url: "{{ registry_url }}"
+    username: "{{ item.username }}"
+    password: "{{ item.password }}"
+    registry_url: "{{ item.registry_url }}"
+  loop: "{{ vault.docker_registries }}"
+  loop_control:
+    label: "{{ item.registry_url }}"
+  no_log: true
+  changed_when: false
   # Log in to the private Docker registry using the provided credentials.
   # The `registry_user`, `registry_password`, and `registry_url` variables should be defined in group variables or an Ansible Vault.
 # Notes:

--- a/maintenance/docker-login/login.yml
+++ b/maintenance/docker-login/login.yml
@@ -10,11 +10,15 @@
   tasks:  # Define the list of tasks to execute.
 
     # Task 1: Log in to the private Docker registry
-    - name: Docker login to private registry
-      community.docker.docker_login:  # Use the Ansible `docker_login` module to log into the Docker registry.
-        username: "{{ registry_user }}"  # Specifies the username for the Docker registry.
-        password: "{{ registry_password }}"  # Specifies the password for the Docker registry.
-        registry_url: "{{ registry_url }}"  # Specifies the URL of the Docker registry.
+    - name: Docker login to private registries
+      community.docker.docker_login:
+        username: "{{ item.username }}"
+        password: "{{ item.password }}"
+        registry_url: "{{ item.registry_url }}"
+      loop: "{{ vault.docker_registries }}"
+      loop_control:
+        label: "{{ item.registry_url }}"
+      no_log: true
       changed_when: false
       # This task logs into the private Docker registry using the credentials and URL provided in the group variables.
       # The credentials (`registry_user` and `registry_password`) and the registry URL (`registry_url`) are securely

--- a/vault.template.yml
+++ b/vault.template.yml
@@ -1,6 +1,13 @@
 ---
 
 vault:
+  docker_registries:
+    - registry_url: "registry1.example.com"
+      username: ""
+      password: ""
+    - registry_url: "ghcr.io"
+      username: ""
+      password: ""
   shared:
     general:
       domain: "example.com"


### PR DESCRIPTION
This pull request updates the Home Assistant deployment and related automation scripts to improve Docker registry authentication, update service versions, and enhance Zigbee2MQTT configuration and service placement. The most important changes are grouped below:

**Docker Registry Authentication Improvements:**

* Refactored Docker login tasks in both `docker_install` and `maintenance/docker-login` to support logging into multiple private registries using a new `vault.docker_registries` variable, instead of single registry variables. This allows for more flexible and secure credential management. [[1]](diffhunk://#diff-d71d483b6c7780f16295293a2d48f714200e9650e21682293a7aec8a237bdf82L69-R78) [[2]](diffhunk://#diff-e57c8a03281e5ab41ea3f09a5e5f812ba7370869247031c8db19c8f18a288dc1L13-R21) [[3]](diffhunk://#diff-e7d845d88ea7477b2f94efd2d2753e95679324b284a41016f8fb2148f18c03dfR4-R10)

**Service Version Updates:**

* Updated image versions for `homeassistant`, `zigbee2mqtt`, and `mqtt` to the latest releases in `group_vars/all.yml` for improved security and features.

**Home Assistant Deployment & Storage Changes:**

* Changed persistent storage paths from `/mnt/nfs/docker/...` to `/exports/docker/...` throughout the Docker Compose template, and removed explicit references to NFS in comments and documentation, making the storage backend more generic. [[1]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81L77-R76) [[2]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81L185-R185) [[3]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81L260-R263) [[4]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81L14) [[5]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81L23) [[6]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81L330-L337) [[7]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81L347) [[8]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81L363)
* Added Docker Swarm placement constraints to ensure that Home Assistant, Zigbee2MQTT, and MQTT services are scheduled only on nodes labeled with `storage == true`, improving reliability and data locality. [[1]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81R123-R125) [[2]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81R219-R221) [[3]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81R299-R301)

**Zigbee2MQTT Enhancements:**

* Updated the Zigbee2MQTT image source to use the official GitHub Container Registry (`ghcr.io/koenkk/zigbee2mqtt`) and added advanced settings for device availability monitoring and `last_seen` timestamps in `zigbee/configuration.yaml`. [[1]](diffhunk://#diff-e830f57c835fb77cfda195a0c1bec7b69607f7f5ff4a518ba98a6a41aea01d81L172-R172) [[2]](diffhunk://#diff-ff09d5f5b3568618dcb8b67f0a3e4638f0fba9a6d0eb68b3e1476640f1145c86R84-R101)

These changes collectively improve security, maintainability, and reliability of the Home Assistant deployment.