### PR TITLE
Add Docker Swarm node management playbooks

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,5 @@
 [defaults]
-roles_path = deployments/_shared/roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
+roles_path = docker-swarm/roles:deployments/_shared/roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 command_warnings = False
 deprecation_warnings = False
 duplicate_dict_key = ignore
-

--- a/docker-swarm/node-management/README.md
+++ b/docker-swarm/node-management/README.md
@@ -1,0 +1,175 @@
+# 🐳 Docker Swarm Node Management
+
+Focused Ansible runbooks for changing Docker Swarm membership one node at a
+time. Use these playbooks when you want to add, drain, demote, or remove a
+single node without running the full cluster create or destroy flow.
+
+> [!IMPORTANT]
+> Run every command from the repository root so `ansible.cfg`, inventory, vault
+> settings, and relative role paths resolve consistently.
+
+---
+
+## ✨ What These Playbooks Do
+
+| Action | Playbook | Target group | Result |
+| --- | --- | --- | --- |
+| ➕ Add manager | `add-manager.yml` | `manager` | Mounts NFS, installs Docker, joins as manager, applies labels |
+| ➕ Add worker | `add-worker.yml` | `docker` | Mounts NFS, installs Docker, joins as worker, applies labels |
+| ➖ Remove manager | `remove-manager.yml` | `manager` | Drains, demotes, leaves swarm, removes node entry |
+| ➖ Remove worker | `remove-worker.yml` | `docker` | Drains, leaves swarm, removes node entry |
+
+---
+
+## 🧭 Before You Run
+
+- 🗂️ Keep the target host in inventory for the whole operation.
+- 🧑‍✈️ Put manager nodes in the `manager` group.
+- 🧰 Put worker nodes in the `docker` group.
+- 🧱 Keep all Swarm nodes under the `cluster` group.
+- 💾 Keep the NFS server in `nfs_servers`.
+- 🔑 Make sure SSH works for the target and the control manager.
+- 🗳️ For manager removal, confirm quorum will remain after the change.
+
+The first host in `manager` is used as the control manager by default. If that
+host is the node being changed, pass `swarm_manager=<existing-manager>`.
+
+> [!TIP]
+> Keep the inventory change and the playbook run together. Add a new host before
+> running an add playbook, and remove a decommissioned host only after the remove
+> playbook succeeds.
+
+---
+
+## ⚙️ Variables
+
+| Variable | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `target_node` | ✅ Yes | None | Inventory hostname to add or remove |
+| `swarm_manager` | No | `groups['manager'][0]` | Existing manager used for join tokens and node operations |
+| `swarm_manager_addr` | No | `<swarm_manager default IPv4>:2377` | Join address advertised to new nodes |
+| `swarm_node_name` | No | Target inventory short hostname | Docker Swarm node name, when it differs from inventory |
+| `skip_node_leave` | No | `false` | Skip SSH to an offline target during removal |
+
+---
+
+## 🚀 Add A Manager
+
+Add the new host to the `manager` group in `inventory.yml`, then run:
+
+```bash
+ansible-playbook -i inventory.yml docker-swarm/node-management/add-manager.yml \
+  -e target_node=<new-manager-hostname> \
+  --ask-vault-pass
+```
+
+If the new host is first in the `manager` group, choose an existing manager for
+the control-plane work:
+
+```bash
+ansible-playbook -i inventory.yml docker-swarm/node-management/add-manager.yml \
+  -e target_node=<new-manager-hostname> \
+  -e swarm_manager=<existing-manager-hostname> \
+  --ask-vault-pass
+```
+
+---
+
+## 🧰 Add A Worker
+
+Add the new host to the `docker` group in `inventory.yml`, then run:
+
+```bash
+ansible-playbook -i inventory.yml docker-swarm/node-management/add-worker.yml \
+  -e target_node=<new-worker-hostname> \
+  --ask-vault-pass
+```
+
+---
+
+## 🧑‍✈️ Remove A Manager
+
+Keep the manager in inventory for the removal run:
+
+```bash
+ansible-playbook -i inventory.yml docker-swarm/node-management/remove-manager.yml \
+  -e target_node=<manager-hostname> \
+  --ask-vault-pass
+```
+
+If the target is first in the `manager` group, use another active manager for
+control-plane operations:
+
+```bash
+ansible-playbook -i inventory.yml docker-swarm/node-management/remove-manager.yml \
+  -e target_node=<manager-hostname> \
+  -e swarm_manager=<existing-manager-hostname> \
+  --ask-vault-pass
+```
+
+After a successful run, remove the host from inventory if it is being
+decommissioned.
+
+> [!WARNING]
+> Do not remove the last manager. For steady-state clusters, prefer an odd
+> number of managers and confirm the remaining managers are healthy before
+> changing membership.
+
+---
+
+## 🧹 Remove A Worker
+
+Keep the worker in inventory for the removal run:
+
+```bash
+ansible-playbook -i inventory.yml docker-swarm/node-management/remove-worker.yml \
+  -e target_node=<worker-hostname> \
+  --ask-vault-pass
+```
+
+After a successful run, remove the host from inventory if it is being
+decommissioned.
+
+---
+
+## 📴 Offline Targets
+
+If the target is already offline, skip the SSH step that asks the node to leave
+the swarm and force-remove the node entry from a manager:
+
+```bash
+ansible-playbook -i inventory.yml docker-swarm/node-management/remove-worker.yml \
+  -e target_node=<worker-hostname> \
+  -e skip_node_leave=true \
+  --ask-vault-pass
+```
+
+The same option works for manager removal:
+
+```bash
+ansible-playbook -i inventory.yml docker-swarm/node-management/remove-manager.yml \
+  -e target_node=<manager-hostname> \
+  -e swarm_manager=<existing-manager-hostname> \
+  -e skip_node_leave=true \
+  --ask-vault-pass
+```
+
+> [!CAUTION]
+> Offline manager removal still changes manager membership and can affect
+> quorum. Use an active manager for `swarm_manager` and verify the cluster state
+> afterwards.
+
+---
+
+## ✅ Verification
+
+Check membership from a manager after each run:
+
+```bash
+ansible -i inventory.yml <manager-hostname> -b -a "docker node ls"
+```
+
+For add operations, verify the new node is `Ready` and `Active`.
+
+For remove operations, verify the removed node no longer appears in
+`docker node ls`, then update inventory if the host is gone for good.

--- a/docker-swarm/node-management/add-manager.yml
+++ b/docker-swarm/node-management/add-manager.yml
@@ -26,7 +26,7 @@
 # control manager is also used later to apply labels because node metadata is a
 # manager-side operation.
 - name: Get manager join details
-  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  hosts: "{{ swarm_manager | default('manager[0]') }}"
   become: true
   gather_facts: true
   tasks:
@@ -104,7 +104,7 @@
 # Labels are applied from the control manager after the node is visible in the
 # manager API. This mirrors the inventory-driven labels used by create.yml.
 - name: Apply labels to manager node
-  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  hosts: "{{ swarm_manager | default('manager[0]') }}"
   become: true
   gather_facts: false
   tasks:

--- a/docker-swarm/node-management/add-manager.yml
+++ b/docker-swarm/node-management/add-manager.yml
@@ -129,16 +129,12 @@
       until: node_management_node_inspect.rc == 0
       changed_when: false
 
-    # Labels are optional. If swarm_labels is absent or empty for the target,
-    # this loop has no items and no labels are changed.
+    # Match the existing assign_labels role behavior: when swarm_labels is
+    # defined, replace the full label map. An empty dictionary intentionally
+    # clears stale labels so placement constraints cannot linger.
     - name: Apply swarm labels
-      ansible.builtin.command:
-        argv:
-          - docker
-          - node
-          - update
-          - "--label-add"
-          - "{{ item.key }}={{ item.value }}"
-          - "{{ node_management_target_node_name }}"
-      loop: "{{ hostvars[target_node].swarm_labels | default({}) | dict2items }}"
-      changed_when: true
+      community.docker.docker_node:
+        hostname: "{{ node_management_target_node_name }}"
+        labels: "{{ hostvars[target_node].swarm_labels }}"
+        labels_state: replace
+      when: hostvars[target_node].swarm_labels is defined

--- a/docker-swarm/node-management/add-manager.yml
+++ b/docker-swarm/node-management/add-manager.yml
@@ -1,0 +1,144 @@
+---
+# Add a single node to the existing Docker Swarm as a manager.
+#
+# Required:
+# - target_node: inventory hostname of the manager being added. The host must
+#   already exist in the inventory's `manager` group.
+#
+# Optional:
+# - swarm_manager: existing manager used to retrieve the join token. Defaults
+#   to the first host in the `manager` group.
+# - swarm_manager_addr: explicit `<host>:2377` join address for the cluster.
+# - swarm_node_name: Docker Swarm node name when it differs from inventory.
+#
+# This playbook intentionally configures only one target node. It does not
+# rebuild the cluster or touch existing managers beyond token lookup and labels.
+
+# The mount_nfs role derives nfs_server_host from nfs_servers host facts.
+# Gathering them up front keeps the add-node workflow independent of a prior
+# full-cluster playbook run.
+- name: Gather NFS server facts
+  hosts: nfs_servers
+  gather_facts: true
+  tasks: []
+
+# Manager join tokens can only be read from an existing Swarm manager. The
+# control manager is also used later to apply labels because node metadata is a
+# manager-side operation.
+- name: Get manager join details
+  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Validate manager add inputs
+      ansible.builtin.assert:
+        that:
+          - target_node is defined
+          - target_node | default('') in groups['manager']
+          - target_node | default('') != (swarm_manager | default(groups['manager'][0]))
+        fail_msg: >-
+          Set target_node to the inventory hostname being added, ensure it is in
+          the manager group, and use swarm_manager for an existing manager if
+          the target is first in the manager group.
+
+    # Use the current token from the cluster instead of storing join tokens in
+    # inventory or vault. This keeps token rotation transparent to the playbook.
+    - name: Get manager join token
+      ansible.builtin.command:
+        argv:
+          - docker
+          - swarm
+          - join-token
+          - -q
+          - manager
+      register: node_management_manager_token
+      changed_when: false
+
+    # swarm_manager_addr lets the operator override the advertised address when
+    # the manager's default IPv4 address is not reachable from the new node.
+    - name: Set manager join address
+      ansible.builtin.set_fact:
+        node_management_manager_address: "{{ swarm_manager_addr | default(ansible_default_ipv4.address ~ ':2377') }}"
+
+# The new manager receives the same baseline node configuration as nodes added
+# during docker-swarm/create.yml: NFS mount, Docker install, daemon config, and
+# registry login.
+- name: Add manager node
+  hosts: "{{ target_node | default('missing_target_node') }}"
+  become: true
+  gather_facts: true
+  roles:
+    - role: ../roles/mount_nfs
+    - role: ../roles/docker_install
+  tasks:
+    # docker_install can notify a Docker restart after daemon config changes.
+    # Flush before `docker swarm join` so the join happens against the final
+    # service configuration.
+    - name: Apply Docker handlers before joining
+      ansible.builtin.meta: flush_handlers
+
+    # Docker reports `Swarm: inactive` for a node that is not yet a member.
+    # Existing members are left untouched, which makes re-runs safe.
+    - name: Check swarm status
+      ansible.builtin.command:
+        argv:
+          - docker
+          - info
+      register: node_management_swarm_status
+      changed_when: false
+
+    # Join as a manager only when the target is not already part of a Swarm.
+    - name: Join node as manager
+      ansible.builtin.command:
+        argv:
+          - docker
+          - swarm
+          - join
+          - --token
+          - "{{ hostvars[swarm_manager | default(groups['manager'][0])].node_management_manager_token.stdout }}"
+          - "{{ hostvars[swarm_manager | default(groups['manager'][0])].node_management_manager_address }}"
+      register: node_management_join_manager
+      changed_when: "'This node joined a swarm as a manager' in node_management_join_manager.stdout"
+      when: "'Swarm: inactive' in node_management_swarm_status.stdout"
+
+# Labels are applied from the control manager after the node is visible in the
+# manager API. This mirrors the inventory-driven labels used by create.yml.
+- name: Apply labels to manager node
+  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  become: true
+  gather_facts: false
+  tasks:
+    # Docker Swarm usually uses the host's short name as the node name. Override
+    # with swarm_node_name when Docker and inventory do not match.
+    - name: Set target node name
+      ansible.builtin.set_fact:
+        node_management_target_node_name: "{{ swarm_node_name | default(hostvars[target_node].inventory_hostname_short | default(target_node)) }}"
+
+    # The join can return before the node is immediately inspectable from the
+    # manager. Retry briefly before applying labels.
+    - name: Wait for manager node to be visible
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - inspect
+          - "{{ node_management_target_node_name }}"
+      register: node_management_node_inspect
+      retries: 10
+      delay: 3
+      until: node_management_node_inspect.rc == 0
+      changed_when: false
+
+    # Labels are optional. If swarm_labels is absent or empty for the target,
+    # this loop has no items and no labels are changed.
+    - name: Apply swarm labels
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - update
+          - "--label-add"
+          - "{{ item.key }}={{ item.value }}"
+          - "{{ node_management_target_node_name }}"
+      loop: "{{ hostvars[target_node].swarm_labels | default({}) | dict2items }}"
+      changed_when: true

--- a/docker-swarm/node-management/add-manager.yml
+++ b/docker-swarm/node-management/add-manager.yml
@@ -68,8 +68,8 @@
   become: true
   gather_facts: true
   roles:
-    - role: ../roles/mount_nfs
-    - role: ../roles/docker_install
+    - role: mount_nfs
+    - role: docker_install
   tasks:
     # docker_install can notify a Docker restart after daemon config changes.
     # Flush before `docker swarm join` so the join happens against the final

--- a/docker-swarm/node-management/add-worker.yml
+++ b/docker-swarm/node-management/add-worker.yml
@@ -121,15 +121,12 @@
       until: node_management_node_inspect.rc == 0
       changed_when: false
 
-    # No-op when the target has no swarm_labels defined in inventory.
+    # Match the existing assign_labels role behavior: when swarm_labels is
+    # defined, replace the full label map. An empty dictionary intentionally
+    # clears stale labels so placement constraints cannot linger.
     - name: Apply swarm labels
-      ansible.builtin.command:
-        argv:
-          - docker
-          - node
-          - update
-          - "--label-add"
-          - "{{ item.key }}={{ item.value }}"
-          - "{{ node_management_target_node_name }}"
-      loop: "{{ hostvars[target_node].swarm_labels | default({}) | dict2items }}"
-      changed_when: true
+      community.docker.docker_node:
+        hostname: "{{ node_management_target_node_name }}"
+        labels: "{{ hostvars[target_node].swarm_labels }}"
+        labels_state: replace
+      when: hostvars[target_node].swarm_labels is defined

--- a/docker-swarm/node-management/add-worker.yml
+++ b/docker-swarm/node-management/add-worker.yml
@@ -63,8 +63,8 @@
   become: true
   gather_facts: true
   roles:
-    - role: ../roles/mount_nfs
-    - role: ../roles/docker_install
+    - role: mount_nfs
+    - role: docker_install
   tasks:
     # Ensure any Docker restart notified by docker_install has completed before
     # the node attempts to join the Swarm.

--- a/docker-swarm/node-management/add-worker.yml
+++ b/docker-swarm/node-management/add-worker.yml
@@ -25,7 +25,7 @@
 # Worker join tokens are read from an existing manager at run time. This avoids
 # storing tokens in source-controlled inventory and works after token rotation.
 - name: Get worker join details
-  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  hosts: "{{ swarm_manager | default('manager[0]') }}"
   become: true
   gather_facts: true
   tasks:
@@ -96,7 +96,7 @@
 
 # Swarm labels must be applied through a manager, not from the worker itself.
 - name: Apply labels to worker node
-  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  hosts: "{{ swarm_manager | default('manager[0]') }}"
   become: true
   gather_facts: false
   tasks:

--- a/docker-swarm/node-management/add-worker.yml
+++ b/docker-swarm/node-management/add-worker.yml
@@ -1,0 +1,135 @@
+---
+# Add a single node to the existing Docker Swarm as a worker.
+#
+# Required:
+# - target_node: inventory hostname of the worker being added. The host must
+#   already exist in the inventory's `docker` group.
+#
+# Optional:
+# - swarm_manager: existing manager used to retrieve the join token. Defaults
+#   to the first host in the `manager` group.
+# - swarm_manager_addr: explicit `<host>:2377` join address for the cluster.
+# - swarm_node_name: Docker Swarm node name when it differs from inventory.
+#
+# This playbook configures only the target worker and leaves existing nodes
+# untouched apart from manager-side token lookup and label application.
+
+# The mount_nfs role depends on nfs_server_host, which is computed from facts on
+# the first host in nfs_servers. Gather those facts before configuring the new
+# worker.
+- name: Gather NFS server facts
+  hosts: nfs_servers
+  gather_facts: true
+  tasks: []
+
+# Worker join tokens are read from an existing manager at run time. This avoids
+# storing tokens in source-controlled inventory and works after token rotation.
+- name: Get worker join details
+  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Validate worker add inputs
+      ansible.builtin.assert:
+        that:
+          - target_node is defined
+          - target_node | default('') in groups['docker']
+        fail_msg: >-
+          Set target_node to the inventory hostname being added and ensure it is
+          in the docker worker group.
+
+    # Use the current worker token from the live Swarm.
+    - name: Get worker join token
+      ansible.builtin.command:
+        argv:
+          - docker
+          - swarm
+          - join-token
+          - -q
+          - worker
+      register: node_management_worker_token
+      changed_when: false
+
+    # Override with swarm_manager_addr if the manager's default IPv4 address is
+    # not the address workers should use for port 2377.
+    - name: Set manager join address
+      ansible.builtin.set_fact:
+        node_management_manager_address: "{{ swarm_manager_addr | default(ansible_default_ipv4.address ~ ':2377') }}"
+
+# New workers get the same node baseline as the full create flow: NFS, Docker,
+# daemon configuration, and registry authentication.
+- name: Add worker node
+  hosts: "{{ target_node | default('missing_target_node') }}"
+  become: true
+  gather_facts: true
+  roles:
+    - role: ../roles/mount_nfs
+    - role: ../roles/docker_install
+  tasks:
+    # Ensure any Docker restart notified by docker_install has completed before
+    # the node attempts to join the Swarm.
+    - name: Apply Docker handlers before joining
+      ansible.builtin.meta: flush_handlers
+
+    # Re-runs are safe: nodes that are already in a Swarm are not joined again.
+    - name: Check swarm status
+      ansible.builtin.command:
+        argv:
+          - docker
+          - info
+      register: node_management_swarm_status
+      changed_when: false
+
+    # Join as a worker only when Docker reports that Swarm mode is inactive.
+    - name: Join node as worker
+      ansible.builtin.command:
+        argv:
+          - docker
+          - swarm
+          - join
+          - --token
+          - "{{ hostvars[swarm_manager | default(groups['manager'][0])].node_management_worker_token.stdout }}"
+          - "{{ hostvars[swarm_manager | default(groups['manager'][0])].node_management_manager_address }}"
+      register: node_management_join_worker
+      changed_when: "'This node joined a swarm as a worker' in node_management_join_worker.stdout"
+      when: "'Swarm: inactive' in node_management_swarm_status.stdout"
+
+# Swarm labels must be applied through a manager, not from the worker itself.
+- name: Apply labels to worker node
+  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  become: true
+  gather_facts: false
+  tasks:
+    # Docker node names normally match inventory short hostnames. Use
+    # swarm_node_name for hosts where that is not true.
+    - name: Set target node name
+      ansible.builtin.set_fact:
+        node_management_target_node_name: "{{ swarm_node_name | default(hostvars[target_node].inventory_hostname_short | default(target_node)) }}"
+
+    # Give the manager API a short window to observe the newly joined worker
+    # before labels are applied.
+    - name: Wait for worker node to be visible
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - inspect
+          - "{{ node_management_target_node_name }}"
+      register: node_management_node_inspect
+      retries: 10
+      delay: 3
+      until: node_management_node_inspect.rc == 0
+      changed_when: false
+
+    # No-op when the target has no swarm_labels defined in inventory.
+    - name: Apply swarm labels
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - update
+          - "--label-add"
+          - "{{ item.key }}={{ item.value }}"
+          - "{{ node_management_target_node_name }}"
+      loop: "{{ hostvars[target_node].swarm_labels | default({}) | dict2items }}"
+      changed_when: true

--- a/docker-swarm/node-management/remove-manager.yml
+++ b/docker-swarm/node-management/remove-manager.yml
@@ -1,0 +1,142 @@
+---
+# Remove a single manager from an existing Docker Swarm.
+#
+# Required:
+# - target_node: inventory hostname of the manager being removed. The host must
+#   remain in the `manager` group for this run.
+#
+# Optional:
+# - swarm_manager: existing manager used for manager-side node operations.
+#   Defaults to the first host in the `manager` group. It must not be the node
+#   being removed.
+# - swarm_node_name: Docker Swarm node name when it differs from inventory.
+# - skip_node_leave: set true when the target is offline and cannot be reached.
+#
+# Manager removal affects cluster quorum. Confirm the remaining managers are
+# healthy before running this playbook.
+
+# Draining and demoting are manager-side operations, so they run from an active
+# control manager rather than on the target node itself.
+- name: Drain and demote manager node
+  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Validate manager removal inputs
+      ansible.builtin.assert:
+        that:
+          - target_node is defined
+          - target_node | default('') in groups['manager']
+          - target_node | default('') != (swarm_manager | default(groups['manager'][0]))
+        fail_msg: >-
+          Set target_node to the manager being removed. If the target is the
+          first manager in the inventory, set swarm_manager to a different
+          existing manager.
+
+    # Resolve the Docker node name once for all manager-side commands. Override
+    # with swarm_node_name if Docker's name does not match inventory.
+    - name: Set target node name
+      ansible.builtin.set_fact:
+        node_management_target_node_name: "{{ swarm_node_name | default(hostvars[target_node].inventory_hostname_short | default(target_node)) }}"
+
+    # Missing nodes are treated as already absent. This keeps the remove flow
+    # useful after a partial previous run or manual cleanup.
+    - name: Check target node exists
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - inspect
+          - "{{ node_management_target_node_name }}"
+      register: node_management_node_inspect
+      failed_when: false
+      changed_when: false
+
+    # Drain first so Swarm reschedules any tasks away from the manager before it
+    # is demoted and removed.
+    - name: Drain manager node
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - update
+          - --availability
+          - drain
+          - "{{ node_management_target_node_name }}"
+      changed_when: true
+      when: node_management_node_inspect.rc == 0
+
+    # Demotion converts the target to a worker before it leaves. This is the
+    # normal Swarm path for removing a manager without tearing down the cluster.
+    - name: Demote manager node
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - demote
+          - "{{ node_management_target_node_name }}"
+      changed_when: true
+      when: node_management_node_inspect.rc == 0
+
+# Once demoted, ask the target node to leave its local Swarm state. This play is
+# skipped with skip_node_leave=true for hosts that are already offline.
+- name: Leave swarm on target manager
+  hosts: "{{ target_node | default('missing_target_node') }}"
+  become: true
+  gather_facts: false
+  tasks:
+    # docker info can fail when Docker is unavailable; that should not hide the
+    # manager-side removal path, especially during recovery.
+    - name: Check local swarm status
+      ansible.builtin.command:
+        argv:
+          - docker
+          - info
+      register: node_management_swarm_status
+      failed_when: false
+      changed_when: false
+      when: not (skip_node_leave | default(false) | bool)
+
+    # --force is required because the node may still have local manager state.
+    - name: Leave swarm
+      ansible.builtin.command:
+        argv:
+          - docker
+          - swarm
+          - leave
+          - --force
+      register: node_management_leave_swarm
+      changed_when: "'Node left the swarm' in node_management_leave_swarm.stdout"
+      when:
+        - not (skip_node_leave | default(false) | bool)
+        - node_management_swarm_status.rc | default(1) == 0
+        - "'Swarm: active' in (node_management_swarm_status.stdout | default(''))"
+
+# Finally remove the node object from the manager's cluster membership list.
+# This also cleans up stale entries for offline targets.
+- name: Remove manager from swarm node list
+  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  become: true
+  gather_facts: false
+  tasks:
+    # Recompute the name in this play because set_fact scope is per-host.
+    - name: Set target node name
+      ansible.builtin.set_fact:
+        node_management_target_node_name: "{{ swarm_node_name | default(hostvars[target_node].inventory_hostname_short | default(target_node)) }}"
+
+    # Force removal handles offline nodes. "Not found" is accepted so the
+    # playbook remains safe to re-run after the node entry is already gone.
+    - name: Remove node
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - rm
+          - --force
+          - "{{ node_management_target_node_name }}"
+      register: node_management_remove_node
+      failed_when:
+        - node_management_remove_node.rc != 0
+        - "'not found' not in node_management_remove_node.stderr"
+        - "'No such node' not in node_management_remove_node.stderr"
+      changed_when: node_management_remove_node.rc == 0

--- a/docker-swarm/node-management/remove-manager.yml
+++ b/docker-swarm/node-management/remove-manager.yml
@@ -18,7 +18,7 @@
 # Draining and demoting are manager-side operations, so they run from an active
 # control manager rather than on the target node itself.
 - name: Drain and demote manager node
-  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  hosts: "{{ swarm_manager | default('manager[0]') }}"
   become: true
   gather_facts: false
   tasks:
@@ -115,7 +115,7 @@
 # Finally remove the node object from the manager's cluster membership list.
 # This also cleans up stale entries for offline targets.
 - name: Remove manager from swarm node list
-  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  hosts: "{{ swarm_manager | default('manager[0]') }}"
   become: true
   gather_facts: false
   tasks:

--- a/docker-swarm/node-management/remove-manager.yml
+++ b/docker-swarm/node-management/remove-manager.yml
@@ -68,6 +68,8 @@
 
     # Demotion converts the target to a worker before it leaves. This is the
     # normal Swarm path for removing a manager without tearing down the cluster.
+    # If a previous run already demoted or removed the node, treat that as
+    # recoverable so the rest of the cleanup can continue.
     - name: Demote manager node
       ansible.builtin.command:
         argv:
@@ -75,7 +77,30 @@
           - node
           - demote
           - "{{ node_management_target_node_name }}"
-      changed_when: true
+      register: node_management_demote_manager
+      failed_when: >-
+        node_management_demote_manager.rc != 0 and
+        'not found' not in (
+          (node_management_demote_manager.stdout | default('') ~ ' ' ~
+          node_management_demote_manager.stderr | default('')) | lower
+        ) and
+        'no such node' not in (
+          (node_management_demote_manager.stdout | default('') ~ ' ' ~
+          node_management_demote_manager.stderr | default('')) | lower
+        ) and
+        'not a manager' not in (
+          (node_management_demote_manager.stdout | default('') ~ ' ' ~
+          node_management_demote_manager.stderr | default('')) | lower
+        ) and
+        'not a swarm manager' not in (
+          (node_management_demote_manager.stdout | default('') ~ ' ' ~
+          node_management_demote_manager.stderr | default('')) | lower
+        ) and
+        'already a worker' not in (
+          (node_management_demote_manager.stdout | default('') ~ ' ' ~
+          node_management_demote_manager.stderr | default('')) | lower
+        )
+      changed_when: node_management_demote_manager.rc == 0
       when: node_management_node_inspect.rc == 0
 
 # Once demoted, ask the target node to leave its local Swarm state. This play is

--- a/docker-swarm/node-management/remove-worker.yml
+++ b/docker-swarm/node-management/remove-worker.yml
@@ -17,7 +17,7 @@
 # Draining is a manager-side operation. Run it from an active manager before
 # asking the worker to leave its local Swarm state.
 - name: Drain worker node
-  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  hosts: "{{ swarm_manager | default('manager[0]') }}"
   become: true
   gather_facts: false
   tasks:
@@ -98,7 +98,7 @@
 
 # Remove the worker object from the cluster membership list on a manager.
 - name: Remove worker from swarm node list
-  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  hosts: "{{ swarm_manager | default('manager[0]') }}"
   become: true
   gather_facts: false
   tasks:

--- a/docker-swarm/node-management/remove-worker.yml
+++ b/docker-swarm/node-management/remove-worker.yml
@@ -1,0 +1,125 @@
+---
+# Remove a single worker from an existing Docker Swarm.
+#
+# Required:
+# - target_node: inventory hostname of the worker being removed. The host must
+#   remain in the `docker` group for this run.
+#
+# Optional:
+# - swarm_manager: existing manager used for manager-side node operations.
+#   Defaults to the first host in the `manager` group.
+# - swarm_node_name: Docker Swarm node name when it differs from inventory.
+# - skip_node_leave: set true when the target is offline and cannot be reached.
+#
+# The playbook drains the worker before removal so Swarm can reschedule tasks
+# away from the node.
+
+# Draining is a manager-side operation. Run it from an active manager before
+# asking the worker to leave its local Swarm state.
+- name: Drain worker node
+  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Validate worker removal inputs
+      ansible.builtin.assert:
+        that:
+          - target_node is defined
+          - target_node | default('') in groups['docker']
+        fail_msg: >-
+          Set target_node to the worker being removed and ensure it is in the
+          docker worker group.
+
+    # Docker node names normally match inventory short hostnames. Use
+    # swarm_node_name when they differ.
+    - name: Set target node name
+      ansible.builtin.set_fact:
+        node_management_target_node_name: "{{ swarm_node_name | default(hostvars[target_node].inventory_hostname_short | default(target_node)) }}"
+
+    # Treat missing nodes as already absent. This helps when recovering from a
+    # partial removal or a manually deleted Swarm node.
+    - name: Check target node exists
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - inspect
+          - "{{ node_management_target_node_name }}"
+      register: node_management_node_inspect
+      failed_when: false
+      changed_when: false
+
+    # Drain before removing so active service tasks can be rescheduled by Swarm.
+    - name: Drain worker node
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - update
+          - --availability
+          - drain
+          - "{{ node_management_target_node_name }}"
+      changed_when: true
+      when: node_management_node_inspect.rc == 0
+
+# Ask the worker to clear its local Swarm state. For offline nodes, pass
+# skip_node_leave=true and the manager-side force removal will still run.
+- name: Leave swarm on target worker
+  hosts: "{{ target_node | default('missing_target_node') }}"
+  become: true
+  gather_facts: false
+  tasks:
+    # docker info can fail when Docker is unavailable. Keep that non-fatal so
+    # stale manager-side entries can still be removed.
+    - name: Check local swarm status
+      ansible.builtin.command:
+        argv:
+          - docker
+          - info
+      register: node_management_swarm_status
+      failed_when: false
+      changed_when: false
+      when: not (skip_node_leave | default(false) | bool)
+
+    # --force makes the local leave idempotent enough for operational cleanup.
+    - name: Leave swarm
+      ansible.builtin.command:
+        argv:
+          - docker
+          - swarm
+          - leave
+          - --force
+      register: node_management_leave_swarm
+      changed_when: "'Node left the swarm' in node_management_leave_swarm.stdout"
+      when:
+        - not (skip_node_leave | default(false) | bool)
+        - node_management_swarm_status.rc | default(1) == 0
+        - "'Swarm: active' in (node_management_swarm_status.stdout | default(''))"
+
+# Remove the worker object from the cluster membership list on a manager.
+- name: Remove worker from swarm node list
+  hosts: "{{ swarm_manager | default(groups['manager'][0]) }}"
+  become: true
+  gather_facts: false
+  tasks:
+    # Recompute the name in this play because set_fact scope is per-host.
+    - name: Set target node name
+      ansible.builtin.set_fact:
+        node_management_target_node_name: "{{ swarm_node_name | default(hostvars[target_node].inventory_hostname_short | default(target_node)) }}"
+
+    # Accept "not found" so the playbook can be re-run safely after the node has
+    # already disappeared from the manager's view.
+    - name: Remove node
+      ansible.builtin.command:
+        argv:
+          - docker
+          - node
+          - rm
+          - --force
+          - "{{ node_management_target_node_name }}"
+      register: node_management_remove_node
+      failed_when:
+        - node_management_remove_node.rc != 0
+        - "'not found' not in node_management_remove_node.stderr"
+        - "'No such node' not in node_management_remove_node.stderr"
+      changed_when: node_management_remove_node.rc == 0


### PR DESCRIPTION
  Introduce focused Ansible runbooks for adding and removing individual
  Docker Swarm managers and workers without running the full cluster create
  or destroy flows.

  The new node-management folder includes playbooks for:
  - adding a manager
  - adding a worker
  - removing a manager
  - removing a worker

  The add flows prepare the target node with the existing NFS and Docker
  roles, retrieve fresh join tokens from an active manager, join the node to
  the swarm, and apply inventory-defined labels.

  The remove flows drain the target node, handle manager demotion where
  needed, ask reachable nodes to leave the swarm, and force-remove stale
  node entries from the manager view when appropriate.

  Also add documentation covering usage, required variables, safety notes,
  offline target handling, and post-run verification.