### PR TITLE
Protect rendered compose files during stack deploys

### DIFF
--- a/deployments/README.md
+++ b/deployments/README.md
@@ -11,6 +11,10 @@ This directory includes deployments for a variety of services, ranging from pers
 - Provide examples of best practices for deploying containerized applications.
 - Ensure services are configured with proper proxying, DNS resolution, and HTTPS certificates.
 
+## Temporary Compose Files
+
+Deployments that use the shared `copy_and_deploy` role render Docker Compose templates to `/home/docker-compose/docker-compose.yaml` before applying them with `community.docker.docker_stack`. Some templates include vault-backed values that are still present in the rendered compose file, so the shared role keeps the working directory private to `root`, writes the compose file with `0600` permissions, suppresses template output with `no_log`, and removes the temporary directory in an `always` block after deployment.
+
 ## Deployments
 
 ### 1. [Cioban](cioban/README.md)

--- a/deployments/_shared/roles/copy_and_deploy/tasks/main.yml
+++ b/deployments/_shared/roles/copy_and_deploy/tasks/main.yml
@@ -1,19 +1,26 @@
 ---
-- name: Copy compose from template to host
-  ansible.builtin.template:
-    src: "templates/docker-compose.yaml"  # Jinja2 source for the stack definition.
-    dest: "/home/docker-compose/docker-compose.yaml"  # Rendered compose file consumed by docker_stack.
-    mode: '0755'  # Readable by runtime processes; writable by owner.
-    owner: nobody  # Aligns with shared NFS ownership used by this project.
-    group: nogroup
-  # Render the compose file before deploying the stack.
+- name: Render and deploy stack from protected compose file
+  block:
+    - name: Copy compose from template to host
+      ansible.builtin.template:
+        src: "templates/docker-compose.yaml"  # Jinja2 source for the stack definition.
+        dest: "/home/docker-compose/docker-compose.yaml"  # Rendered compose file consumed by docker_stack.
+        mode: '0600'  # Restrict rendered vault-backed values to root on the deployment host.
+        owner: root
+        group: root
+      no_log: true  # Prevent secret-bearing templates from leaking through task output or --diff.
+      # Render the compose file before deploying the stack.
 
-- name: Deploy Services
-  community.docker.docker_stack:
-    name: "{{ copy_and_deploy_stack_name }}"
-    compose:
-      - /home/docker-compose/docker-compose.yaml
-    state: present
-  register: copy_and_deploy_swarm_check # Store the output of the command for debugging or logging purposes.
-  changed_when: false  # Keeps output stable for repeated deploy runs.
-  # Deploy or update the stack on the Swarm manager.
+    - name: Deploy Services
+      community.docker.docker_stack:
+        name: "{{ copy_and_deploy_stack_name }}"
+        compose:
+          - /home/docker-compose/docker-compose.yaml
+        state: present
+      register: copy_and_deploy_swarm_check # Store the output of the command for debugging or logging purposes.
+      changed_when: false  # Keeps output stable for repeated deploy runs.
+      # Deploy or update the stack on the Swarm manager.
+  always:
+    - name: Clean up protected compose directory
+      ansible.builtin.include_role:
+        name: cleanup

--- a/deployments/_shared/roles/docker_prereqs_and_stop/tasks/main.yml
+++ b/deployments/_shared/roles/docker_prereqs_and_stop/tasks/main.yml
@@ -28,6 +28,6 @@
   ansible.builtin.file:
     path: /home/docker-compose
     state: directory
-    mode: '0755'
-    owner: nobody
-    group: nogroup
+    mode: '0700'
+    owner: root
+    group: root


### PR DESCRIPTION
## 🧭 Summary

Protects temporary rendered Docker Compose files used by the shared deploy role so vault-backed values are not left world-readable on deployment hosts. The shared role now renders compose files as `root:root` with `0600`, suppresses template output with `no_log`, and cleans up the temporary compose directory in an `always` block.

Closes #67.

## 📦 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ Feature or enhancement
- [ ] 🚀 New deployment
- [x] 📚 Documentation
- [x] 🔧 Chore or maintenance
- [ ] 📦 Dependency update
- [ ] 🚨 Breaking change

## 🧪 Validation

```text
git diff --check
ansible-lint
```

## 🔐 Secrets and Configuration

- [x] No secrets, tokens, private keys, or sensitive values are committed
- [x] New secret values are documented in `vault.template.yml`
- [x] New inventory assumptions are documented
- [x] Public exposure, ports, and Traefik routing have been reviewed

No new secret values, inventory assumptions, public ports, or Traefik routes are introduced.

## 🛠️ Operational Notes

The shared deployment flow now removes `/home/docker-compose` from the `copy_and_deploy` role even if stack deployment fails. Existing caller cleanup tasks remain safe because removing an absent directory is idempotent.

## 📸 Screenshots or Logs

```text
ansible-lint
Passed: 0 failure(s), 0 warning(s) on 170 files.
```
