### PR TITLE
Secure Traefik dashboard exposure

### DIFF
--- a/deployments/traefik/README.md
+++ b/deployments/traefik/README.md
@@ -29,6 +29,8 @@ The deployment process involves preparing the environment, ensuring the required
 
 The deployment emphasizes security by encrypting sensitive data, restricting permissions on configuration files, and automating the issuance of SSL/TLS certificates. It is recommended to test the deployment in a staging environment before applying it to production.
 
+The Traefik dashboard and API are not published directly on the host. The insecure API listener is disabled, API debug endpoints are disabled, and dashboard access is routed through `https://traefik.<domain>` with a Traefik IP allowlist middleware. Configure trusted dashboard source ranges in `vault.services.traefik.dashboard.allowed_ips` as a comma-separated list. Set `vault.services.traefik.dashboard.enabled` to `false` to disable the dashboard route entirely.
+
 ## Troubleshooting
 
 Common issues such as missing directories, uninitialized Docker Swarm, or misconfigured secrets can be resolved by verifying the environment setup and reviewing Ansible playbook logs.

--- a/deployments/traefik/group_vars/all.yml
+++ b/deployments/traefik/group_vars/all.yml
@@ -8,9 +8,13 @@ traefik:
   ports:
     web: "{{ ((vault.services.traefik | default({})).ports | default({})).web | default('80') }}"
     websecure: "{{ ((vault.services.traefik | default({})).ports | default({})).websecure | default('443') }}"
-    dashboard_internal: "{{ ((vault.services.traefik | default({})).ports | default({})).dashboard_internal | default('8080') }}"
-    dashboard: "{{ ((vault.services.traefik | default({})).ports | default({})).dashboard | default('8080') }}"
     ssh: "{{ ((vault.services.traefik | default({})).ports | default({})).ssh | default('2222') }}"
+
+  # Dashboard/API exposure through the HTTPS router.
+  # `allowed_ips` is a comma-separated Traefik source range list.
+  dashboard:
+    enabled: "{{ ((vault.services.traefik | default({})).dashboard | default({})).enabled | default(true) }}"
+    allowed_ips: "{{ ((vault.services.traefik | default({})).dashboard | default({})).allowed_ips | default('10.0.0.0/8,172.16.0.0/12,192.168.0.0/16') }}"
 
   # Pinned image tag for reproducible deployments
   version: "3.6.11"

--- a/deployments/traefik/templates/docker-compose.yaml
+++ b/deployments/traefik/templates/docker-compose.yaml
@@ -24,12 +24,12 @@ services:
       # Disables sending anonymous usage data to Traefik.
 
       # API and dashboard
-      - "--api.insecure=true"
-      # Enables the Traefik API and dashboard without authentication. Use cautiously in production.
-      - "--api.dashboard=true"
-      # Enables the Traefik dashboard.
-      - "--api.debug=true"
-      # Enables debug mode for the API.
+      - "--api.insecure=false"
+      # Disables the unauthenticated dashboard/API listener on port 8080.
+      - "--api.dashboard={{ (traefik.dashboard.enabled | bool) | ternary('true', 'false') }}"
+      # Exposes the dashboard only through the protected HTTPS router below.
+      - "--api.debug=false"
+      # Keeps API debug endpoints disabled.
 
       - "--log.level=DEBUG"
       - "--log.filePath=/logs/traefik.log"
@@ -89,16 +89,18 @@ services:
         # Ensures that the Traefik service is deployed only on manager nodes in the Swarm cluster.
 
       labels:
-        - "traefik.enable=true"
-        # Enables Traefik integration for this service.
+        - "traefik.enable={{ (traefik.dashboard.enabled | bool) | ternary('true', 'false') }}"
+        # Enables or disables the Traefik dashboard/API route from shared configuration.
         - "traefik.http.routers.traefik.entrypoints=web"
         # Configures the HTTP entry point for the Traefik router.
         - "traefik.http.routers.traefik.rule=Host(`traefik.{{ vault.shared.general.domain }}`)"
         # Specifies the routing rule for the Traefik dashboard.
+        - "traefik.http.middlewares.traefik-dashboard-allowlist.ipallowlist.sourcerange={{ traefik.dashboard.allowed_ips }}"
+        # Limits dashboard/API access to the configured trusted source ranges.
         - "traefik.http.middlewares.traefik-https-redirect.redirectscheme.scheme=https"
         # Redirects HTTP traffic to HTTPS.
-        - "traefik.http.routers.traefik.middlewares=traefik-https-redirect"
-        # Applies the HTTPS redirection middleware to the Traefik router.
+        - "traefik.http.routers.traefik.middlewares=traefik-dashboard-allowlist,traefik-https-redirect"
+        # Applies the allowlist and HTTPS redirection middleware to the Traefik router.
         - "traefik.http.routers.traefik-secure.entrypoints=websecure"
         # Configures the HTTPS entry point for the Traefik router.
         - "traefik.http.routers.traefik-secure.rule=Host(`traefik.{{ vault.shared.general.domain }}`)"
@@ -107,10 +109,10 @@ services:
         # Enables TLS for the secure Traefik router.
         - "traefik.http.routers.traefik-secure.tls.certresolver=letsencrypt"
         # Configures Let's Encrypt as the certificate resolver for the secure router.
-        - "traefik.http.routers.traefik-secure.service=traefik"
-        # Associates the secure router with the Traefik service.
-        - "traefik.http.services.traefik.loadbalancer.server.port={{ traefik.ports.dashboard_internal }}"
-        # Specifies the internal port (8080) of the Traefik service for the dashboard.
+        - "traefik.http.routers.traefik-secure.middlewares=traefik-dashboard-allowlist"
+        # Applies the trusted source range allowlist to HTTPS dashboard/API requests.
+        - "traefik.http.routers.traefik-secure.service=api@internal"
+        # Routes the protected dashboard/API host to Traefik's internal API service.
         - "traefik.docker.network=proxy"
         # Specifies the Docker network that Traefik should use.
 
@@ -119,8 +121,6 @@ services:
       # Maps port 80 on the host to port 80 in the container for HTTP traffic.
       - "{{ traefik.ports.websecure }}:443"
       # Maps port 443 on the host to port 443 in the container for HTTPS traffic.
-      - "{{ traefik.ports.dashboard }}:{{ traefik.ports.dashboard_internal }}"
-      # Maps port 8080 on the host to port 8080 in the container for the Traefik dashboard.
       - "{{ traefik.ports.ssh }}:2222"
       # Maps port 2222 on the host to port 2222 in the container for SSH traffic.
 

--- a/vault.template.yml
+++ b/vault.template.yml
@@ -67,6 +67,7 @@ vault:
       ports:
         web: "80"
         websecure: "443"
-        dashboard_internal: "8080"
-        dashboard: "8080"
         ssh: "2222"
+      dashboard:
+        enabled: true
+        allowed_ips: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"


### PR DESCRIPTION
## 🧭 Summary

Secures Traefik dashboard/API exposure by disabling the insecure API listener, removing the direct dashboard host port publish, and routing dashboard access through the existing HTTPS hostname with a configurable IP allowlist.

Closes #73.

## 📦 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ Feature or enhancement
- [ ] 🚀 New deployment
- [x] 📚 Documentation
- [x] 🔧 Chore or maintenance
- [ ] 📦 Dependency update
- [ ] 🚨 Breaking change

## 🧪 Validation

```text
git diff --check
ansible-lint
```

## 🔐 Secrets and Configuration

- [x] No secrets, tokens, private keys, or sensitive values are committed
- [x] New secret values are documented in `vault.template.yml`
- [x] New inventory assumptions are documented
- [x] Public exposure, ports, and Traefik routing have been reviewed

No new secret values are committed. The new dashboard controls are documented in `vault.template.yml`, and the Traefik dashboard route now defaults to trusted private source ranges instead of a direct host port publish.

## 🛠️ Operational Notes

Existing vault files should remove the old `vault.services.traefik.ports.dashboard` and `dashboard_internal` values if present. To customize dashboard access, set `vault.services.traefik.dashboard.enabled` and `vault.services.traefik.dashboard.allowed_ips`.

## 📸 Screenshots or Logs

```text
ansible-lint
Passed: 0 failure(s), 0 warning(s) on 170 files.
```
