### PR TITLE
Harden NFS export configuration permissions

### DIFF
--- a/docker-swarm/README.md
+++ b/docker-swarm/README.md
@@ -61,6 +61,7 @@ To execute a playbook, use the appropriate command for the desired playbook.
 1. Always back up critical configuration files (e.g., `/etc/exports` for NFS) before running destructive playbooks.
 2. Test the playbooks in a non-production environment before deploying to production.
 3. Store sensitive information (e.g., SSH keys, Docker registry credentials) securely using [Ansible Vault](https://docs.ansible.com/ansible/latest/vault_guide/index.html). See [`vault.template.yml`](../vault.template.yml) at the repo root for the full variable reference.
+4. Keep NFS export rules separate from data permissions: the setup role manages `/etc/exports` as `root:root` with mode `0644`.
 
 ## Troubleshooting
 

--- a/docker-swarm/roles/setup_nfs_server/tasks/main.yml
+++ b/docker-swarm/roles/setup_nfs_server/tasks/main.yml
@@ -30,9 +30,9 @@
   ansible.builtin.template:
     src: "templates/exports.j2"  # Path to the Jinja2 template for the NFS exports configuration.
     dest: "/etc/exports"  # Destination path for the NFS exports configuration file.
-    mode: '7777'  # Set the file permissions to allow full access (read, write, execute) for all users.
-    owner: nobody  # Set the file owner to `nobody`.
-    group: nogroup  # Set the file group to `nogroup`.
+    mode: '0644'  # Allow only root to modify the NFS export rules.
+    owner: root  # Keep this system configuration file owned by root.
+    group: root
   notify:
     - Restart NFS Server  # Notify the handler to restart the NFS server after the configuration is updated.
   # This task copies the NFS exports configuration file to the target system and ensures it has the correct permissions.
@@ -43,5 +43,5 @@
 # - The `templates/exports.j2` file should define the NFS export rules, such as which clients can access the share
 #   and their permissions (e.g., read-only or read-write).
 # - The `notify` directive ensures that the NFS server is restarted after the exports file is updated.
-# - The `7777` permissions on the directory and file are very permissive and should be adjusted based on your security requirements.
+# - The exported directory permissions must support container access, while `/etc/exports` remains root-owned.
 # - Ensure that the NFS server is properly configured to allow access from the intended clients.


### PR DESCRIPTION
## 🧭 Summary

Manage `/etc/exports` as `root:root` with mode `0644` so unprivileged users cannot modify or execute the NFS export configuration. Document the permission boundary between the NFS configuration file and the exported data directory.

Closes #75

## 📦 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ Feature or enhancement
- [ ] 🚀 New deployment
- [x] 📚 Documentation
- [ ] 🔧 Chore or maintenance
- [ ] 📦 Dependency update
- [ ] 🚨 Breaking change

## 🧪 Validation

```text
ansible-lint
ansible-playbook -i inventory.example.yml docker-swarm/create.yml --syntax-check
git diff --check
```

All checks passed. `ansible-lint` reported 0 failures and 0 warnings across 170 files.

## 🔐 Secrets and Configuration

- [x] No secrets, tokens, private keys, or sensitive values are committed
- [x] No new secret values require changes to `vault.template.yml`
- [x] No new inventory assumptions are introduced
- [x] No public exposure, ports, or Traefik routing are changed

Configuration impact is limited to changing `/etc/exports` ownership from `nobody:nogroup` to `root:root` and mode from `7777` to `0644`.

## 🛠️ Operational Notes

The next run of `docker-swarm/create.yml` will apply the corrected metadata and notify the existing NFS restart handler. No export rules, mount paths, or stored data change. The `/exports/docker` data directory permissions remain unchanged and are intentionally outside this issue.

No migration is required. Rollback is to revert this commit and rerun the NFS setup role, though that restores the insecure permissions.

Assumption: unprivileged processes do not need write or execute access to `/etc/exports`.

## 📸 Screenshots or Logs

Not applicable; this is an Ansible file-metadata change.
