### PR TITLE
Make Cioban registry config mount deterministic

### DIFF
--- a/deployments/cioban/README.md
+++ b/deployments/cioban/README.md
@@ -57,4 +57,4 @@ The playbook checks the configured path on every manager before stopping the exi
 
 - **Absolute-path assertion fails**: remove `~` or relative components and set `cioban_docker_config_path` to an absolute manager-host path.
 - **Protected-file assertion fails**: run the Docker login maintenance playbook on every cluster node, then verify ownership and mode on the named manager.
-- **Cioban cannot inspect a private registry**: confirm the registry entry exists in the configured Docker file on every manager and rerun the login playbook after credential rotation.
+- **Cioban cannot inspect a private registry**: confirm the registry entry exists in the Docker configuration file at `cioban_docker_config_path` on every manager and rerun the login playbook after credential rotation.

--- a/deployments/cioban/README.md
+++ b/deployments/cioban/README.md
@@ -2,32 +2,59 @@
 
 [![Ansible](https://img.shields.io/badge/Ansible-Automation-EE0000?logo=ansible&logoColor=white&style=flat-square)](https://docs.ansible.com/) [![Docker Swarm](https://img.shields.io/badge/Docker%20Swarm-Orchestration-2496ED?logo=docker&logoColor=white&style=flat-square)](https://docs.docker.com/engine/swarm/) ![Auto Update](https://img.shields.io/badge/Auto%20Update-Service%20Images-2EA44F?style=flat-square) ![Docker Socket](https://img.shields.io/badge/Docker%20Socket-Required-2496ED?logo=docker&logoColor=white&style=flat-square) ![Cioban](https://img.shields.io/badge/cioban-v0.17.14-5C5C5C?style=flat-square)
 
-This project provides an automated solution for deploying and managing the **Cioban** stack in a Docker Swarm cluster using Ansible. It is designed to ensure scalability, high availability, and secure integration with external services.
+This deployment runs **Cioban** as a single Docker Swarm service that checks labelled services for image updates. Ansible validates the registry configuration file on every manager before it replaces the existing service and deploys the rendered stack.
 
 ## Overview
 
-The deployment process uses Ansible playbooks and roles to prepare the environment, configure Docker Swarm, and deploy the stack. It includes support for managing secrets, setting up NFS directories, and integrating with external services like reverse proxies and DNS providers.
+Cioban needs two privileged host resources:
 
-## Features
+- `/var/run/docker.sock`, mounted read-write so Cioban can update Swarm services.
+- A Docker CLI configuration file, mounted read-only at `/root/.docker/config.json` so Cioban can inspect private registries.
 
-- **Docker Swarm Integration**: Deploys services across a Swarm cluster for high availability and scalability.
-- **Secure Secrets Management**: Uses Ansible Vault and Docker secrets to handle sensitive data securely.
-- **NFS Support**: Ensures required directories are created and mounted for persistent storage.
-- **Modular Roles**: Simplifies maintenance and reusability with dedicated roles for tasks like NFS setup, Docker configuration, and stack deployment.
-- **Customizable**: Easily extendable to add new services or adapt to specific requirements.
+The service can run on any manager node. The host-side Docker configuration must therefore exist with the same path, ownership, and permissions on every manager.
+
+## Configuration
+
+The default host path is defined in [`group_vars/all.yml`](group_vars/all.yml):
+
+```yaml
+cioban_docker_config_path: "/root/.docker/config.json"
+```
+
+Override it with an inventory variable when required, but keep it absolute. Tilde expansion and other shell shortcuts are intentionally rejected because Docker resolves bind sources in the deployment execution context.
 
 ## Prerequisites
 
-To deploy the stack, you need a Docker Swarm cluster, Ansible installed on the control machine, and access to an NFS server. Secrets and configuration values must be defined and encrypted using Ansible Vault.
+Before deploying Cioban:
+
+1. Ensure the `manager` inventory group contains every Swarm manager.
+2. Authenticate every cluster node to the configured private registries:
+
+   ```bash
+   ansible-playbook -i inventory.yml maintenance/docker-login/login.yml --ask-vault-pass
+   ```
+
+3. Confirm `cioban_docker_config_path` is a regular file owned by `root:root` with mode `0600` on every manager.
 
 ## Deployment Process
 
-The deployment involves preparing the environment, ensuring the required directory structure exists, and deploying the stack using Docker Swarm. The process is automated through Ansible playbooks and roles, ensuring consistency and reliability.
+Run the deployment from the repository root:
+
+```bash
+ansible-playbook -i inventory.yml deployments/cioban/deploy.yml
+```
+
+The playbook checks the configured path on every manager before stopping the existing Cioban service. A missing, non-regular, incorrectly owned, or incorrectly permissioned file stops the run without replacing the service. After the checks pass, one selected manager deploys the stack.
 
 ## Security Considerations
 
-The deployment emphasizes security by encrypting sensitive data, restricting permissions, and using Docker secrets for secure communication between services. It is recommended to test configurations in a staging environment before applying them to production.
+- Never commit Docker registry credentials to this repository.
+- Keep the host configuration owned by `root:root` with mode `0600`; the container mount remains read-only.
+- Treat Cioban as a privileged service. Its read-write Docker socket gives it control over the Swarm manager, independently of the registry configuration mount.
+- Rotate registry credentials with the Docker login maintenance playbook so every manager stays consistent.
 
 ## Troubleshooting
 
-Common issues such as missing directories, uninitialized Docker Swarm, or misconfigured secrets can be resolved by verifying the environment setup and reviewing Ansible playbook logs.
+- **Absolute-path assertion fails**: remove `~` or relative components and set `cioban_docker_config_path` to an absolute manager-host path.
+- **Protected-file assertion fails**: run the Docker login maintenance playbook on every cluster node, then verify ownership and mode on the named manager.
+- **Cioban cannot inspect a private registry**: confirm the registry entry exists in the configured Docker file on every manager and rerun the login playbook after credential rotation.

--- a/deployments/cioban/deploy.yml
+++ b/deployments/cioban/deploy.yml
@@ -15,8 +15,8 @@
     - name: Validate Cioban Docker config path
       ansible.builtin.assert:
         that:
-          - cioban_docker_config_path is string
-          - (cioban_docker_config_path | regex_search('^/')) is not none
+          - (cioban_docker_config_path | default('')) is string
+          - ((cioban_docker_config_path | default('')) | regex_search('^/')) is not none
         fail_msg: >-
           cioban_docker_config_path must be an absolute path on every Swarm
           manager; shell shortcuts such as ~ are not supported.

--- a/deployments/cioban/deploy.yml
+++ b/deployments/cioban/deploy.yml
@@ -12,6 +12,40 @@
     # Use one selected manager host for deployment to avoid `run_once` strategy caveats.
     cioban_deploy_host: "{{ ansible_play_hosts_all | first }}"
   tasks:
+    - name: Validate Cioban Docker config path
+      ansible.builtin.assert:
+        that:
+          - cioban_docker_config_path is string
+          - (cioban_docker_config_path | regex_search('^/')) is not none
+        fail_msg: >-
+          cioban_docker_config_path must be an absolute path on every Swarm
+          manager; shell shortcuts such as ~ are not supported.
+        quiet: true
+
+    - name: Inspect Cioban Docker config
+      ansible.builtin.stat:
+        path: "{{ cioban_docker_config_path }}"
+        follow: false
+        get_attributes: false
+        get_checksum: false
+        get_mime: false
+      register: cioban_docker_config
+
+    - name: Require protected Cioban Docker config
+      ansible.builtin.assert:
+        that:
+          - cioban_docker_config.stat.exists | default(false)
+          - cioban_docker_config.stat.isreg | default(false)
+          - (cioban_docker_config.stat.pw_name | default('')) == 'root'
+          - (cioban_docker_config.stat.gr_name | default('')) == 'root'
+          - (cioban_docker_config.stat.mode | default('')) == '0600'
+        fail_msg: >-
+          {{ cioban_docker_config_path }} on {{ inventory_hostname }} must be a
+          root:root regular file with mode 0600. Create or update it with
+          maintenance/docker-login/login.yml, then correct its ownership and
+          mode on every manager before deploying Cioban.
+        quiet: true
+
     - name: Deploy Cioban stack
       ansible.builtin.include_role:
         name: deploy
@@ -23,4 +57,4 @@
 # - This playbook assumes that the Docker Swarm cluster is already initialized and functional.
 # - Always test the deployment in a staging environment before applying it to production.
 # - Use `become: true` cautiously and ensure that the user running the playbook has the necessary sudo privileges.
-# - Tasks run only on the first host selected for the play, ensuring a single-manager deployment.
+# - Preflight checks run on every manager; stack deployment runs only on the selected host.

--- a/deployments/cioban/group_vars/all.yml
+++ b/deployments/cioban/group_vars/all.yml
@@ -1,3 +1,6 @@
 ---
 # Version pinning for Cioban deployment
 cioban_version: "0.17.14"
+
+# Root's Docker login stores private-registry credentials here by default.
+cioban_docker_config_path: "/root/.docker/config.json"

--- a/deployments/cioban/templates/docker-compose.yaml
+++ b/deployments/cioban/templates/docker-compose.yaml
@@ -27,7 +27,10 @@ services:
       # Mounts the Docker socket to allow the service to interact with the Docker API.
       # This is required for Cioban to manage and update other services.
       # Use caution as this grants the container full access to the Docker daemon.
-      - '~/.docker/config.json:/root/.docker/config.json:ro'
+      - type: bind
+        source: "{{ cioban_docker_config_path }}"
+        target: /root/.docker/config.json
+        read_only: true
       # Mounts the Docker configuration file to provide access to private registries.
       # The file is mounted as read-only (`ro`) for security.
 
@@ -43,7 +46,7 @@ services:
 # Notes:
 # - Ensure that the Docker Swarm cluster is properly configured before deploying this stack.
 # - The `volumes` section grants the container significant privileges. Use it only in trusted environments.
-# - Replace `~/.docker/config.json` with the appropriate path to the Docker configuration file on the host.
+# - `cioban_docker_config_path` must reference a protected config file on every manager node.
 # - The `SLEEP_TIME` and `FILTER_SERVICES` environment variables can be adjusted to customize the update behavior.
 # - If Traefik is used for routing, set `traefik.enable` to `true` and configure additional labels for routing rules.
 # - Always test changes in a staging environment before deploying to production.

--- a/deployments/cioban/templates/docker-compose.yaml
+++ b/deployments/cioban/templates/docker-compose.yaml
@@ -32,7 +32,7 @@ services:
         target: /root/.docker/config.json
         read_only: true
       # Mounts the Docker configuration file to provide access to private registries.
-      # The file is mounted as read-only (`ro`) for security.
+      # The read_only setting prevents Cioban from modifying the host credential file.
 
     environment:
       SLEEP_TIME: '1m'


### PR DESCRIPTION
## 🧭 Summary

Replace Cioban's tilde-based Docker configuration bind source with the configurable absolute `cioban_docker_config_path`, which defaults to `/root/.docker/config.json`. This removes controller-home expansion from the rendered stack and gives every Swarm manager the same host-path contract.

The deployment now validates the configured path on every manager before replacing the existing service. It must be a regular file owned by `root:root` with mode `0600`; the container mount remains read-only. The README documents provisioning, overrides, credential rotation, security boundaries, and failure recovery.

Closes #69

## 📦 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ Feature or enhancement
- [ ] 🚀 New deployment
- [x] 📚 Documentation
- [ ] 🔧 Chore or maintenance
- [ ] 📦 Dependency update
- [ ] 🚨 Breaking change

## 🧪 Validation

```text
ansible-playbook -i inventory.example.yml deployments/cioban/deploy.yml --syntax-check
ansible-lint deployments/cioban/deploy.yml
ansible-lint
git diff --check
```

All commands passed. Full lint reported 0 failures and 0 warnings across 170 files. Default and overridden compose templates were rendered with Ansible and parsed by `docker stack config`; both retained an absolute host source, the `/root/.docker/config.json` container target, and a read-only mount. Targeted assertion tests accepted an absolute path and rejected a tilde path, and the task listing confirmed that all preflight checks precede deployment.

A live Swarm deployment and private-registry authentication test were not run because they require managed cluster nodes and credentials.

## 🔐 Secrets and Configuration

- [x] No secrets, tokens, private keys, or sensitive values are committed
- [x] No new secret values require changes to `vault.template.yml`
- [x] New inventory assumptions are documented
- [x] No public exposure, ports, or Traefik routing are changed

`cioban_docker_config_path` defaults to `/root/.docker/config.json` and must reference a regular `root:root` file with mode `0600` on every manager. The credential file remains read-only inside the container. Cioban's existing read-write Docker socket mount is unchanged and continues to grant privileged manager access.

## 🛠️ Operational Notes

Before deployment or credential rotation, run `maintenance/docker-login/login.yml` on every cluster node and confirm the configured file metadata on every manager. A failed preflight leaves the existing Cioban service untouched. No persistent data, port, routing, or image-version changes are included.

Rollback is to revert this commit and redeploy, though that restores the context-dependent tilde bind source. Cioban remains pinned to `0.17.14`; migration from the archived upstream project is intentionally outside this fix.
