### PR TITLE
Correct Dozzle service cleanup target

### DIFF
--- a/deployments/dozzle/README.md
+++ b/deployments/dozzle/README.md
@@ -6,7 +6,7 @@ This directory contains an Ansible-based deployment for **Dozzle** using Docker 
 
 ## What this deployment does
 
-- Stops any running `dozzle_dozzel` service before redeployment.
+- Stops any running `dozzle_dozzle` service before redeployment.
 - Renders a Docker Compose stack definition from a Jinja2 template.
 - Deploys the stack to Docker Swarm using `docker stack deploy`.
 - Exposes Dozzle through Traefik with automatic HTTPS redirection and Let's Encrypt TLS certificates.
@@ -65,4 +65,4 @@ Common issues and their resolutions:
 - **Service not accessible**: confirm Traefik is running and DNS resolves `dozzle.<domain>` to your cluster ingress IP.
 - **TLS certificate issues**: verify Traefik ACME configuration and that `web`/`websecure` entrypoints are active.
 - **Missing logs**: ensure `/var/run/docker.sock` is mounted and readable by the Dozzle container.
-- **Deployment conflicts**: if an old service remains, manually remove it with `docker service rm dozzle_dozzel` and redeploy.
+- **Deployment conflicts**: if an old service remains, manually remove it with `docker service rm dozzle_dozzle` and redeploy.

--- a/deployments/dozzle/roles/deploy/tasks/main.yml
+++ b/deployments/dozzle/roles/deploy/tasks/main.yml
@@ -5,9 +5,9 @@
   ansible.builtin.include_role:
     name: docker_prereqs_and_stop
   vars:
-    # Swarm service name generated from stack + service: dozzle_dozzel.
+    # Swarm service name generated from stack + service: dozzle_dozzle.
     docker_prereqs_and_stop_services_to_stop:
-      - dozzle_dozzel
+      - dozzle_dozzle
 
 # Render compose template and deploy/update the dozzle stack.
 - name: Deploy Services


### PR DESCRIPTION
## 🧭 Summary

Correct the Dozzle pre-deployment cleanup target from `dozzle_dozzel` to the Swarm-generated `dozzle_dozzle`, so reruns remove the service created by the `dozzle` stack. Update the deployment README and manual recovery command to use the same name.

Closes #70

## 📦 Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ Feature or enhancement
- [ ] 🚀 New deployment
- [x] 📚 Documentation
- [ ] 🔧 Chore or maintenance
- [ ] 📦 Dependency update
- [ ] 🚨 Breaking change

## 🧪 Validation

```text
ansible-lint
ansible-playbook --syntax-check -i inventory.example.yml deployments/dozzle/deploy.yml
docker compose -f deployments/dozzle/templates/docker-compose.yaml config --services
docker stack config --compose-file deployments/dozzle/templates/docker-compose.yaml
rg -n -S 'dozzle_dozzel|dozzle_dozzle' deployments/dozzle
git diff --check
```

All commands passed locally. Full lint reported 0 failures and 0 warnings across 170 files. Compose reported the `dozzle` service, and `docker stack config` parsed the stack with the same service key. Docker Compose also emitted the pre-existing warning that the top-level `version` field is obsolete.

A live Swarm redeploy was not run because the local Docker engine is not in Swarm mode and no managed inventory or Vault is available.

## 🔐 Secrets and Configuration

- [x] No secrets, tokens, private keys, or sensitive values are committed
- [x] No new secret values require changes to `vault.template.yml`
- [x] No new inventory assumptions are introduced
- [x] No public exposure, ports, or Traefik routing are changed

This change only corrects the generated service name used by cleanup and documentation.

## 🛠️ Operational Notes

On the next Dozzle deployment, the pre-deployment role will remove `dozzle_dozzle` before recreating the stack. This matches the existing intended behavior but creates a service interruption; if deployment fails after removal, rerun the playbook after correcting the failure.

No migration or persistent-data change is required. Rollback is to revert the commit, though that restores the incorrect cleanup target. On a managed cluster, verify the service before and after redeployment with `docker service ls` and confirm global tasks are healthy with `docker service ps dozzle_dozzle`.
